### PR TITLE
Add json deref, and expose direct json schema

### DIFF
--- a/packages/ui/lib/json-schema.ts
+++ b/packages/ui/lib/json-schema.ts
@@ -1,26 +1,38 @@
 import { z } from "zod/v4";
 import { JSONSchema } from "zod/v4/core";
 
-export interface ZodToJsonSchemaOptions<T extends z.ZodRawShape> {
+export interface JsonSchemaReformatOptions<T extends any = unknown> {
   selectFields?: (keyof T)[];
   firstFields?: (keyof T)[];
   lastFields?: (keyof T)[];
   hideFields?: (keyof T)[];
+  dereference?: boolean;
 }
 
 export function zodToJsonSchema<T extends z.ZodRawShape>(
   zodSchema: z.ZodObject<T>,
+  options: Omit<JsonSchemaReformatOptions<T>, "dereference"> = {}
+): JSONSchema.ObjectSchema {
+  const jsonSchema: JSONSchema.BaseSchema = z.toJSONSchema(zodSchema, {
+    reused: "inline",
+  });
+  return modifyJsonSchema(jsonSchema, options);
+}
+
+export function modifyJsonSchema<T extends any = unknown>(
+  jsonSchema: JSONSchema.BaseSchema,
   {
     selectFields,
     firstFields = [],
     lastFields = [],
     hideFields = [],
-  }: ZodToJsonSchemaOptions<T> = {},
+    dereference = true,
+  }: JsonSchemaReformatOptions<T>
 ): JSONSchema.ObjectSchema {
-  const jsonSchema: JSONSchema.BaseSchema = z.toJSONSchema(zodSchema, {
-    reused: "inline",
-  });
-  const jsonObjectSchema = jsonSchema as JSONSchema.ObjectSchema;
+  let jsonObjectSchema = jsonSchema as JSONSchema.ObjectSchema;
+  if (dereference) {
+    jsonObjectSchema = derefLocalRefs(jsonObjectSchema);
+  }
   const updatedProperties = { ...jsonObjectSchema.properties };
 
   const exclude = new Set(hideFields);
@@ -28,8 +40,8 @@ export function zodToJsonSchema<T extends z.ZodRawShape>(
   const rawOrder: (keyof T)[] = (firstFields || [])
     .concat(
       (selectFields ?? (Object.keys(updatedProperties) as (keyof T)[])).filter(
-        (x) => !shiftedFields.has(x),
-      ),
+        (x) => !shiftedFields.has(x)
+      )
     )
     .concat(lastFields || []);
 
@@ -42,16 +54,13 @@ export function zodToJsonSchema<T extends z.ZodRawShape>(
   });
   const result = {
     ...jsonObjectSchema,
-    properties: orderedAndFiltered.reduce(
-      (acc, field) => {
-        const key = String(field);
-        if (updatedProperties[key] !== undefined) {
-          acc[key] = updatedProperties[key] as JSONSchema.BaseSchema;
-        }
-        return acc;
-      },
-      {} as Record<string, JSONSchema.BaseSchema>,
-    ),
+    properties: orderedAndFiltered.reduce((acc, field) => {
+      const key = String(field);
+      if (updatedProperties[key] !== undefined) {
+        acc[key] = updatedProperties[key] as JSONSchema.BaseSchema;
+      }
+      return acc;
+    }, {} as Record<string, JSONSchema.BaseSchema>),
   };
 
   // Return as JSONSchema.ObjectSchema
@@ -93,7 +102,7 @@ export function getSchemaType(schema: JSONSchema.BaseSchema): string {
     };
     // For union, find the first non-null type
     const nonNullSchema = unionSchema.anyOf?.find(
-      (subSchema: JSONSchema.BaseSchema) => subSchema.type !== "null",
+      (subSchema: JSONSchema.BaseSchema) => subSchema.type !== "null"
     );
     if (nonNullSchema) {
       return getSchemaType(nonNullSchema);
@@ -109,7 +118,7 @@ export function getSchemaType(schema: JSONSchema.BaseSchema): string {
     };
     // For intersect, find the first non-null type
     const nonNullSchema = intersectSchema.allOf?.find(
-      (subSchema: JSONSchema.BaseSchema) => subSchema.type !== "null",
+      (subSchema: JSONSchema.BaseSchema) => subSchema.type !== "null"
     );
     if (nonNullSchema) {
       return getSchemaType(nonNullSchema);
@@ -131,7 +140,7 @@ export function getSchemaType(schema: JSONSchema.BaseSchema): string {
  * Helper functions to check schema types
  */
 export function isArraySchema(
-  schema: JSONSchema.BaseSchema,
+  schema: JSONSchema.BaseSchema
 ): schema is JSONSchema.ArraySchema {
   return schema.type === "array";
 }
@@ -144,13 +153,13 @@ export function extractFirstNotNullableSchema(schema: JSONSchema.BaseSchema): {
   if (schema.type === undefined && schema.anyOf) {
     const anyNullable =
       schema.anyOf?.some(
-        (subSchema: JSONSchema.BaseSchema) => subSchema.type === "null",
+        (subSchema: JSONSchema.BaseSchema) => subSchema.type === "null"
       ) ?? false;
     if (anyNullable) {
       return {
         isNullable: true,
         schema: schema.anyOf?.find(
-          (subSchema: JSONSchema.BaseSchema) => subSchema.type !== "null",
+          (subSchema: JSONSchema.BaseSchema) => subSchema.type !== "null"
         ),
       };
     }
@@ -161,7 +170,7 @@ export function extractFirstNotNullableSchema(schema: JSONSchema.BaseSchema): {
   if (schema.type === undefined && schema.allOf) {
     const allNullable =
       schema.allOf?.some(
-        (subSchema: JSONSchema.BaseSchema) => subSchema.type === "null",
+        (subSchema: JSONSchema.BaseSchema) => subSchema.type === "null"
       ) ?? false;
     if (allNullable) {
       return { isNullable: true, schema: undefined };
@@ -174,7 +183,54 @@ export function extractFirstNotNullableSchema(schema: JSONSchema.BaseSchema): {
 }
 
 export function isObjectSchema(
-  schema: JSONSchema.BaseSchema,
+  schema: JSONSchema.BaseSchema
 ): schema is JSONSchema.ObjectSchema {
   return schema.type === "object";
+}
+
+export function derefLocalRefs<T extends JSONSchema.BaseSchema>(schema: T): T {
+  const root = schema;
+  const cache = new Map<any, any>(); // handle cycles
+
+  function cloneAndDeref(node: any, trail: string[] = []): any {
+    if (node && typeof node === "object") {
+      if (cache.has(node)) return cache.get(node);
+
+      // $ref?
+      if (typeof node.$ref === "string" && node.$ref.startsWith("#/")) {
+        const target = resolvePointer(root, node.$ref);
+        // merge with siblings (spec allows siblings, could either merge or override)
+        const { $ref, ...rest } = node;
+        const expanded = cloneAndDeref(target, trail.concat([node.$ref]));
+        return cloneAndDeref({ ...expanded, ...rest }, trail);
+      }
+
+      const out: any = Array.isArray(node) ? [] : {};
+      cache.set(node, out);
+      for (const [k, v] of Object.entries(node)) {
+        out[k] = cloneAndDeref(v, trail.concat([k]));
+      }
+      return out;
+    }
+    return node;
+  }
+
+  return cloneAndDeref(schema);
+}
+
+function resolvePointer(obj: any, pointer: string) {
+  // pointer like "#/foo/bar"
+  const parts = pointer.slice(2).split("/").map(unescapeToken);
+  let cur = obj;
+  for (const p of parts) {
+    if (cur == null || typeof cur !== "object" || !(p in cur)) {
+      throw new Error(`Pointer ${pointer} not found at "${p}"`);
+    }
+    cur = cur[p];
+  }
+  return cur;
+}
+
+function unescapeToken(t: string) {
+  return t.replace(/~1/g, "/").replace(/~0/g, "~");
 }


### PR DESCRIPTION
Zod exports aren't going well with v4. I faked v4 support of json-schema to zod, but it's running into bugs with records. We don't really need the zod types, so this starts adding utilities to move away from them. Mainly a dereference utility.

I looked a bit into libraries to do this, but they had varying degrees of not being maintained, and were generally too heavyweight. They would try to resolve remote refs, with options to disable. However they're all generally async, which makes the usage really awkward when you just want to fixup some simple json schema.

This makes me a little sad to entirely lose the typescript types on the client. I think perhaps a better pattern for the template might be to export the json schema json file, and then some vanilla ts types alongside it:

https://www.npmjs.com/package/json-schema-to-typescript