### PR TITLE
Add reconnect logic to workflow task hook

### DIFF
--- a/packages/ui/src/workflow-task/store/reconnect-manager.ts
+++ b/packages/ui/src/workflow-task/store/reconnect-manager.ts
@@ -1,0 +1,131 @@
+export type TaskStatus = "running" | "complete" | "failed" | undefined;
+
+export interface SchedulerHandle {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  id: any;
+}
+
+export interface Scheduler {
+  schedule(fn: () => void, delayMs: number): SchedulerHandle;
+  cancel(handle: SchedulerHandle | null | undefined): void;
+}
+
+export interface ReconnectManagerOptions {
+  scheduler: Scheduler;
+  getTaskStatus: (taskId: string) => TaskStatus;
+  isSubscribed: (taskId: string) => boolean;
+  onSubscribe: (taskId: string) => void;
+  baseMs?: number;
+  maxMs?: number;
+}
+
+export function computeBackoffDelayMs(
+  attempt: number,
+  baseMs: number = 500,
+  maxMs: number = 30000
+): number {
+  const n = Math.max(1, Math.floor(attempt));
+  const delay = baseMs * 2 ** (n - 1);
+  return Math.min(delay, maxMs);
+}
+
+export function isIgnorableStreamError(error: Error): boolean {
+  if (error.name === "AbortError") return true;
+  if (error.name === "TypeError" && error.message.includes("network error")) {
+    return true;
+  }
+  if (error.message.includes("Stream aborted")) return true;
+  return false;
+}
+
+interface RetryStateEntry {
+  attempt: number;
+  handle: SchedulerHandle | null;
+}
+
+export class ReconnectManager {
+  private readonly scheduler: Scheduler;
+  private readonly getTaskStatus: (taskId: string) => TaskStatus;
+  private readonly isSubscribed: (taskId: string) => boolean;
+  private readonly onSubscribe: (taskId: string) => void;
+  private readonly baseMs: number;
+  private readonly maxMs: number;
+
+  private readonly retryState = new Map<string, RetryStateEntry>();
+
+  constructor(options: ReconnectManagerOptions) {
+    this.scheduler = options.scheduler;
+    this.getTaskStatus = options.getTaskStatus;
+    this.isSubscribed = options.isSubscribed;
+    this.onSubscribe = options.onSubscribe;
+    this.baseMs = options.baseMs ?? 500;
+    this.maxMs = options.maxMs ?? 30000;
+  }
+
+  clear(taskId: string): void {
+    const entry = this.retryState.get(taskId);
+    if (entry?.handle) {
+      this.scheduler.cancel(entry.handle);
+    }
+    this.retryState.delete(taskId);
+  }
+
+  reset(taskId: string): void {
+    const entry = this.retryState.get(taskId) ?? { attempt: 0, handle: null };
+    // Cancel any pending attempt when resetting
+    if (entry.handle) {
+      this.scheduler.cancel(entry.handle);
+    }
+    this.retryState.set(taskId, { attempt: 0, handle: null });
+  }
+
+  handleStreamStart(taskId: string): void {
+    this.reset(taskId);
+  }
+
+  handleStreamFinish(taskId: string): void {
+    this.clear(taskId);
+  }
+
+  handleStreamError(taskId: string, error: Error): boolean {
+    if (isIgnorableStreamError(error)) {
+      return false;
+    }
+    const status = this.getTaskStatus(taskId);
+    if (status !== "running") {
+      // Not running anymore; caller should mark failure if desired
+      this.clear(taskId);
+      return false;
+    }
+    this.scheduleNext(taskId);
+    return true;
+  }
+
+  scheduleNext(taskId: string): void {
+    const status = this.getTaskStatus(taskId);
+    if (status !== "running") return;
+    if (this.isSubscribed(taskId)) return;
+
+    const current = this.retryState.get(taskId) ?? { attempt: 0, handle: null };
+    if (current.handle) {
+      this.scheduler.cancel(current.handle);
+    }
+
+    const nextAttempt = current.attempt + 1;
+    const delay = computeBackoffDelayMs(nextAttempt, this.baseMs, this.maxMs);
+
+    const handle = this.scheduler.schedule(() => {
+      // If already subscribed, no-op
+      if (this.isSubscribed(taskId)) return;
+
+      try {
+        this.onSubscribe(taskId);
+      } catch (err) {
+        // Swallow to avoid crashing scheduler; next tick will be rescheduled separately if desired
+      }
+    }, delay);
+
+    this.retryState.set(taskId, { attempt: nextAttempt, handle });
+  }
+}
+

--- a/packages/ui/src/workflow-task/store/task-store.ts
+++ b/packages/ui/src/workflow-task/store/task-store.ts
@@ -18,6 +18,7 @@ import type {
   StreamingEventCallback,
   JSONValue,
 } from "../types";
+import { ReconnectManager, type TaskStatus } from "./reconnect-manager";
 
 export interface TaskStoreState {
   // State
@@ -42,273 +43,224 @@ export interface TaskStoreState {
 }
 
 export const createTaskStore = (client: Client) =>
-  create<TaskStoreState>()((set, get) => ({
-    // Internal retry state for reconnect logic (not exposed in store state)
-    // Map of taskId -> { attempt count and scheduled timeout }
-    // Using closure variables so they don't trigger re-renders
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore - This property is for internal use within the store closure
-    _retryState: new Map<string, { attempt: number; timeoutId: ReturnType<typeof setTimeout> | null }>(),
+  create<TaskStoreState>()((set, get) => {
+    // Scheduler backed by setTimeout/clearTimeout
+    const scheduler = {
+      schedule: (fn: () => void, delayMs: number) => {
+        const id = setTimeout(fn, delayMs);
+        return { id };
+      },
+      cancel: (handle: { id: ReturnType<typeof setTimeout> } | null | undefined) => {
+        if (!handle) return;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        clearTimeout(handle.id as any);
+      },
+    } as const;
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore - helper to schedule reconnection attempts
-    _scheduleReconnect(taskId: string) {
-      // Ensure task still exists and is running
-      const task = get().tasks[taskId];
-      if (!task || task.status !== "running") return;
-      // Skip if already subscribed
-      if (get().isSubscribed(taskId)) return;
-
-      const retryState = (get() as unknown as { _retryState: Map<string, { attempt: number; timeoutId: ReturnType<typeof setTimeout> | null }>; })._retryState;
-      const current = retryState.get(taskId) || { attempt: 0, timeoutId: null };
-
-      // Clear any existing scheduled timeout before scheduling a new one
-      if (current.timeoutId) {
-        clearTimeout(current.timeoutId);
+    const getNarrowTaskStatus = (taskId: string): TaskStatus => {
+      const status = get().tasks[taskId]?.status;
+      if (status === "running" || status === "complete" || status === "failed") {
+        return status;
       }
+      return undefined;
+    };
 
-      const nextAttempt = current.attempt + 1;
-      const baseMs = 500;
-      const maxMs = 30000;
-      const delay = Math.min(baseMs * 2 ** (nextAttempt - 1), maxMs);
+    const reconnectManager = new ReconnectManager({
+      scheduler,
+      getTaskStatus: getNarrowTaskStatus,
+      isSubscribed: (taskId: string) => get().isSubscribed(taskId),
+      onSubscribe: (taskId: string) => {
+        // Avoid tight loops; schedule synchronously to reuse store entry point
+        get().subscribe(taskId);
+      },
+      baseMs: 500,
+      maxMs: 30000,
+    });
 
-      const timeoutId = setTimeout(() => {
-        // If already resubscribed elsewhere, skip
-        if (get().isSubscribed(taskId)) return;
-        try {
-          get().subscribe(taskId);
-        } catch (err) {
-          // eslint-disable-next-line no-console -- visibility for errors
-          console.error(`Reconnect subscribe failed for ${taskId}:`, err);
-          // Schedule another attempt
-          (get() as unknown as { _scheduleReconnect: (id: string) => void })._scheduleReconnect(taskId);
-        }
-      }, delay);
+    return {
+      // Initial state
+      tasks: {},
+      events: {},
 
-      retryState.set(taskId, { attempt: nextAttempt, timeoutId });
-    },
+      // Basic operations
+      clearCompleted: () =>
+        set({
+          tasks: Object.fromEntries(
+            Object.entries(get().tasks).filter(
+              ([, t]) => t.status !== "complete" && t.status !== "failed"
+            )
+          ),
+        }),
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore - helper to clear any scheduled reconnection
-    _clearReconnect(taskId: string) {
-      const retryState = (get() as unknown as { _retryState: Map<string, { attempt: number; timeoutId: ReturnType<typeof setTimeout> | null }>; })._retryState;
-      const entry = retryState.get(taskId);
-      if (entry?.timeoutId) {
-        clearTimeout(entry.timeoutId);
-      }
-      if (entry) {
-        retryState.delete(taskId);
-      }
-    },
-    // Initial state
-    tasks: {},
-    events: {},
-
-    // Basic operations
-    clearCompleted: () =>
-      set({
-        tasks: Object.fromEntries(
-          Object.entries(get().tasks).filter(
-            ([, t]) => t.status !== "complete" && t.status !== "failed"
-          )
-        ),
-      }),
-
-    createTask: async (workflowName: string, input: JSONValue) => {
-      // Call API to create task
-      const workflowHandler = await createTaskAPI({
-        client,
-        eventData: input,
-        workflowName,
-      });
-
-      const task: WorkflowHandlerSummary = {
-        handler_id: workflowHandler.handler_id ?? "",
-        status: "running",
-      };
-
-      // Internal method to set task
-      set((state) => ({
-        tasks: { ...state.tasks, [task.handler_id]: task },
-        events: { ...state.events, [task.handler_id]: [] },
-      }));
-
-      // Automatically subscribe to task events after creation
-      try {
-        get().subscribe(task.handler_id);
-      } catch (error) {
-        // eslint-disable-next-line no-console -- needed
-        console.error(
-          `Failed to auto-subscribe to task ${task.handler_id}:`,
-          error
-        );
-        // Continue execution, subscription can be retried later
-      }
-
-      return task;
-    },
-
-    clearEvents: (taskId: string) =>
-      set((state) => ({
-        events: { ...state.events, [taskId]: [] },
-      })),
-
-    // Server synchronization
-    sync: async () => {
-      try {
-        // 1. Get running tasks from server
-        const serverTasks = await getRunningHandlers({
+      createTask: async (workflowName: string, input: JSONValue) => {
+        // Call API to create task
+        const workflowHandler = await createTaskAPI({
           client,
+          eventData: input,
+          workflowName,
         });
 
-        // 2. Update store with server tasks
-        const newTasksRecord = Object.fromEntries(
-          serverTasks.map((task) => [task.handler_id, task])
-        );
-        set({ tasks: newTasksRecord });
+        const task: WorkflowHandlerSummary = {
+          handler_id: workflowHandler.handler_id ?? "",
+          status: "running",
+        };
 
-        // 3. Auto-subscribe to running tasks
-        serverTasks.forEach((task) => {
-          if (!get().isSubscribed(task.handler_id)) {
-            get().subscribe(task.handler_id);
-          }
-        });
-      } catch (error) {
-        // eslint-disable-next-line no-console -- needed for visibility and tests
-        console.error("Failed to sync with server:", error);
-        // Swallow error to fail gracefully
-      }
-    },
-
-    // Stream subscription management
-    subscribe: (taskId: string) => {
-      const task = get().tasks[taskId];
-      if (!task) {
-        // eslint-disable-next-line no-console -- needed
-        console.warn(`Task ${taskId} not found for subscription`);
-        return;
-      }
-
-      // Check if already subscribed to prevent duplicate subscriptions
-      if (get().isSubscribed(taskId)) {
-        return;
-      }
-
-      // Clear any pending reconnect attempts when (re)subscribing
-      (get() as unknown as { _clearReconnect: (id: string) => void })._clearReconnect(taskId);
-
-      // Create streaming callback
-      const callback: StreamingEventCallback = {
-        onStart: () => {
-          // Reset retry attempts on successful start
-          (get() as unknown as { _retryState: Map<string, { attempt: number; timeoutId: ReturnType<typeof setTimeout> | null }>; })._retryState.set(
-            taskId,
-            { attempt: 0, timeoutId: null }
-          );
-        },
-        onData: (event: WorkflowEvent) => {
-          // Internal method to append event
-          set((state) => ({
-            events: {
-              ...state.events,
-              [taskId]: [...(state.events[taskId] || []), event],
-            },
-          }));
-        },
-        onFinish: () => {
-          // Clear any pending reconnect attempts
-          (get() as unknown as { _clearReconnect: (id: string) => void })._clearReconnect(taskId);
-          // Update task status to complete
-          set((state) => ({
-            tasks: {
-              ...state.tasks,
-              [taskId]: {
-                ...state.tasks[taskId],
-                status: "complete",
-                updatedAt: new Date(),
-              },
-            },
-          }));
-        },
-        onError: (error: Error) => {
-          // Ignore network errors caused by page refresh/unload
-          if (
-            error.name === "AbortError" ||
-            (error.name === "TypeError" &&
-              error.message.includes("network error")) ||
-            error.message.includes("Stream aborted")
-          ) {
-            return;
-          }
-          // Schedule reconnect while task is still running
-          const currentTask = get().tasks[taskId];
-          if (currentTask && currentTask.status === "running") {
-            (get() as unknown as { _scheduleReconnect: (id: string) => void })._scheduleReconnect(taskId);
-            return;
-          }
-          // If not running anymore, mark as failed
-          set((state) => ({
-            tasks: {
-              ...state.tasks,
-              [taskId]: {
-                ...state.tasks[taskId],
-                status: "failed",
-                updatedAt: new Date(),
-              },
-            },
-          }));
-        },
-      };
-
-      // Use handler-based streaming
-      fetchHandlerEvents(
-        { client, handlerId: task.handler_id },
-        callback
-      ).catch((error) => {
-        // Ignore network errors caused by page refresh/unload
-        if (
-          error.name === "AbortError" ||
-          (error.name === "TypeError" &&
-            error.message.includes("network error")) ||
-          error.message.includes("Stream aborted")
-        ) {
-          return;
-        }
-        // On other errors, schedule reconnect while task is running
-        const currentTask = get().tasks[taskId];
-        if (currentTask && currentTask.status === "running") {
-          (get() as unknown as { _scheduleReconnect: (id: string) => void })._scheduleReconnect(taskId);
-          return;
-        }
-        // If not running anymore, mark as failed
+        // Internal method to set task
         set((state) => ({
-          tasks: {
-            ...state.tasks,
-            [taskId]: {
-              ...state.tasks[taskId],
-              status: "failed",
-              updatedAt: new Date(),
-            },
-          },
+          tasks: { ...state.tasks, [task.handler_id]: task },
+          events: { ...state.events, [task.handler_id]: [] },
         }));
-      });
-    },
 
-    unsubscribe: (taskId: string) => {
-      const task = get().tasks[taskId];
-      if (!task) return;
+        // Automatically subscribe to task events after creation
+        try {
+          get().subscribe(task.handler_id);
+        } catch (error) {
+          // eslint-disable-next-line no-console -- needed
+          console.error(
+            `Failed to auto-subscribe to task ${task.handler_id}:`,
+            error
+          );
+          // Continue execution, subscription can be retried later
+        }
 
-      const streamKey = `handler:${taskId}`;
-      workflowStreamingManager.closeStream(streamKey);
-      // Clear any scheduled reconnect
-      (get() as unknown as { _clearReconnect: (id: string) => void })._clearReconnect(taskId);
-    },
+        return task;
+      },
 
-    isSubscribed: (taskId: string): boolean => {
-      const task = get().tasks[taskId];
-      if (!task) return false;
+      clearEvents: (taskId: string) =>
+        set((state) => ({
+          events: { ...state.events, [taskId]: [] },
+        })),
 
-      const streamKey = `handler:${taskId}`;
-      return workflowStreamingManager.isStreamActive(streamKey);
-    },
-  }));
+      // Server synchronization
+      sync: async () => {
+        try {
+          // 1. Get running tasks from server
+          const serverTasks = await getRunningHandlers({
+            client,
+          });
+
+          // 2. Update store with server tasks
+          const newTasksRecord = Object.fromEntries(
+            serverTasks.map((task) => [task.handler_id, task])
+          );
+          set({ tasks: newTasksRecord });
+
+          // 3. Auto-subscribe to running tasks
+          serverTasks.forEach((task) => {
+            if (!get().isSubscribed(task.handler_id)) {
+              get().subscribe(task.handler_id);
+            }
+          });
+        } catch (error) {
+          // eslint-disable-next-line no-console -- needed for visibility and tests
+          console.error("Failed to sync with server:", error);
+          // Swallow error to fail gracefully
+        }
+      },
+
+      // Stream subscription management
+      subscribe: (taskId: string) => {
+        const task = get().tasks[taskId];
+        if (!task) {
+          // eslint-disable-next-line no-console -- needed
+          console.warn(`Task ${taskId} not found for subscription`);
+          return;
+        }
+
+        // Check if already subscribed to prevent duplicate subscriptions
+        if (get().isSubscribed(taskId)) {
+          return;
+        }
+
+        // Clear any pending reconnect attempts when (re)subscribing
+        reconnectManager.clear(taskId);
+
+        // Create streaming callback
+        const callback: StreamingEventCallback = {
+          onStart: () => reconnectManager.handleStreamStart(taskId),
+          onData: (event: WorkflowEvent) => {
+            // Internal method to append event
+            set((state) => ({
+              events: {
+                ...state.events,
+                [taskId]: [...(state.events[taskId] || []), event],
+              },
+            }));
+          },
+          onFinish: () => {
+            // Clear any pending reconnect attempts
+            reconnectManager.handleStreamFinish(taskId);
+            // Update task status to complete
+            set((state) => ({
+              tasks: {
+                ...state.tasks,
+                [taskId]: {
+                  ...state.tasks[taskId],
+                  status: "complete",
+                  updatedAt: new Date(),
+                },
+              },
+            }));
+          },
+          onError: (error: Error) => {
+            const scheduled = reconnectManager.handleStreamError(taskId, error);
+            if (scheduled) return;
+            // If not scheduled (not running or ignorable), and not running anymore, mark as failed
+            const currentTask = get().tasks[taskId];
+            if (!currentTask || currentTask.status !== "running") {
+              set((state) => ({
+                tasks: {
+                  ...state.tasks,
+                  [taskId]: {
+                    ...state.tasks[taskId],
+                    status: "failed",
+                    updatedAt: new Date(),
+                  },
+                },
+              }));
+            }
+          },
+        };
+
+        // Use handler-based streaming
+        fetchHandlerEvents(
+          { client, handlerId: task.handler_id },
+          callback
+        ).catch((error) => {
+          const scheduled = reconnectManager.handleStreamError(taskId, error);
+          if (scheduled) return;
+          const currentTask = get().tasks[taskId];
+          if (!currentTask || currentTask.status !== "running") {
+            set((state) => ({
+              tasks: {
+                ...state.tasks,
+                [taskId]: {
+                  ...state.tasks[taskId],
+                  status: "failed",
+                  updatedAt: new Date(),
+                },
+              },
+            }));
+          }
+        });
+      },
+
+      unsubscribe: (taskId: string) => {
+        const task = get().tasks[taskId];
+        if (!task) return;
+
+        const streamKey = `handler:${taskId}`;
+        workflowStreamingManager.closeStream(streamKey);
+        // Clear any scheduled reconnect
+        reconnectManager.clear(taskId);
+      },
+
+      isSubscribed: (taskId: string): boolean => {
+        const task = get().tasks[taskId];
+        if (!task) return false;
+
+        const streamKey = `handler:${taskId}`;
+        return workflowStreamingManager.isStreamActive(streamKey);
+      },
+    };
+  });

--- a/packages/ui/tests/workflow-task/store/reconnect-manager.test.ts
+++ b/packages/ui/tests/workflow-task/store/reconnect-manager.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  ReconnectManager,
+  type Scheduler,
+  type SchedulerHandle,
+  computeBackoffDelayMs,
+  isIgnorableStreamError,
+} from "../../../src/workflow-task/store/reconnect-manager";
+
+class FakeScheduler implements Scheduler {
+  private now = 0;
+  private queue: Array<{ at: number; fn: () => void; handle: SchedulerHandle & { canceled?: boolean } }> = [];
+
+  schedule(fn: () => void, delayMs: number): SchedulerHandle {
+    const handle: SchedulerHandle & { canceled?: boolean } = { id: Symbol("h") };
+    this.queue.push({ at: this.now + Math.max(0, delayMs), fn, handle });
+    // Keep queue ordered by time
+    this.queue.sort((a, b) => a.at - b.at);
+    return handle;
+  }
+
+  cancel(handle: SchedulerHandle | null | undefined): void {
+    if (!handle) return;
+    // Mark canceled; we'll skip on run
+    const entry = this.queue.find((q) => q.handle === handle);
+    if (entry) entry.handle.canceled = true;
+  }
+
+  advanceBy(ms: number): void {
+    const target = this.now + ms;
+    // Drain tasks up to target time
+    while (true) {
+      // Find earliest task not after target
+      const idx = this.queue.findIndex((q) => q.at <= target);
+      if (idx === -1) break;
+      const [task] = this.queue.splice(idx, 1);
+      this.now = task.at;
+      if (!task.handle.canceled) {
+        task.fn();
+      }
+    }
+    this.now = target;
+  }
+}
+
+describe("ReconnectManager", () => {
+  let scheduler: FakeScheduler;
+  let statusMap: Map<string, "running" | "complete" | "failed">;
+  let activeSubs: Set<string>;
+  let subscribed: string[];
+
+  beforeEach(() => {
+    scheduler = new FakeScheduler();
+    statusMap = new Map();
+    activeSubs = new Set();
+    subscribed = [];
+  });
+
+  const makeManager = () =>
+    new ReconnectManager({
+      scheduler,
+      getTaskStatus: (id) => statusMap.get(id),
+      isSubscribed: (id) => activeSubs.has(id),
+      onSubscribe: (id) => {
+        subscribed.push(id);
+        activeSubs.add(id);
+      },
+      baseMs: 100,
+      maxMs: 5000,
+    });
+
+  it("computes exponential backoff with cap", () => {
+    expect(computeBackoffDelayMs(1, 100, 1000)).toBe(100);
+    expect(computeBackoffDelayMs(2, 100, 1000)).toBe(200);
+    expect(computeBackoffDelayMs(3, 100, 1000)).toBe(400);
+    expect(computeBackoffDelayMs(4, 100, 1000)).toBe(800);
+    expect(computeBackoffDelayMs(5, 100, 1000)).toBe(1000);
+    expect(computeBackoffDelayMs(10, 100, 1000)).toBe(1000);
+  });
+
+  it("identifies ignorable stream errors", () => {
+    expect(isIgnorableStreamError(new Error("Stream aborted by user"))).toBe(true);
+    const abortError = new Error("whatever");
+    abortError.name = "AbortError";
+    expect(isIgnorableStreamError(abortError)).toBe(true);
+    const typeError = new Error("some network error occurred");
+    typeError.name = "TypeError";
+    expect(isIgnorableStreamError(typeError)).toBe(true);
+    expect(isIgnorableStreamError(new Error("Other error"))).toBe(false);
+  });
+
+  it("schedules reconnect when running and not subscribed", () => {
+    const m = makeManager();
+    statusMap.set("t1", "running");
+
+    const scheduled = m.handleStreamError("t1", new Error("boom"));
+    expect(scheduled).toBe(true);
+
+    // Initially not subscribed
+    expect(activeSubs.has("t1")).toBe(false);
+
+    // Advance 100ms (attempt 1)
+    scheduler.advanceBy(100);
+    expect(activeSubs.has("t1")).toBe(true);
+    expect(subscribed).toEqual(["t1"]);
+  });
+
+  it("does not schedule when task is not running", () => {
+    const m = makeManager();
+    statusMap.set("t2", "failed");
+    const scheduled = m.handleStreamError("t2", new Error("boom"));
+    expect(scheduled).toBe(false);
+    scheduler.advanceBy(1000);
+    expect(subscribed).toEqual([]);
+  });
+
+  it("increases delay with attempts and respects clear/reset", () => {
+    const m = makeManager();
+    statusMap.set("t3", "running");
+
+    // first error schedules at 100ms
+    m.handleStreamError("t3", new Error("e1"));
+    scheduler.advanceBy(99);
+    expect(subscribed).toEqual([]);
+    scheduler.advanceBy(1);
+    expect(subscribed).toEqual(["t3"]);
+
+    // unsubscribe scenario: clear and mark unsubscribed
+    m.handleStreamFinish("t3");
+    activeSubs.delete("t3");
+    statusMap.set("t3", "running");
+
+    // second error should schedule at 200ms (attempt 2)
+    m.handleStreamError("t3", new Error("e2"));
+    scheduler.advanceBy(199);
+    expect(subscribed).toEqual(["t3"]);
+    scheduler.advanceBy(1);
+    expect(subscribed).toEqual(["t3", "t3"]);
+
+    // onStart should reset attempts back to 0
+    m.handleStreamStart("t3");
+    activeSubs.delete("t3");
+
+    // next error after reset returns to 100ms
+    m.handleStreamError("t3", new Error("e3"));
+    scheduler.advanceBy(100);
+    expect(subscribed).toEqual(["t3", "t3", "t3"]);
+  });
+
+  it("ignorable errors do not schedule", () => {
+    const m = makeManager();
+    statusMap.set("t4", "running");
+    const e = new Error("Stream aborted");
+    const scheduled = m.handleStreamError("t4", e);
+    expect(scheduled).toBe(false);
+    scheduler.advanceBy(1000);
+    expect(subscribed).toEqual([]);
+  });
+});
+


### PR DESCRIPTION
Add reconnect logic with exponential backoff to `useWorkflowTask` to handle interrupted streaming connections.

The `task-store` now attempts to resubscribe to a workflow task stream with increasing delays (up to 30s) if the connection is lost while the task is still running. This prevents tasks from getting stuck in a disconnected state if, for example, a backend pod restarts. Retries are cleared on successful connection, task completion, or explicit unsubscription, and are not attempted for intentional stream aborts.

---
Linear Issue: [LI-3580](https://linear.app/llamaindex/issue/LI-3580/add-reconnect-logic-in-workflow-task-hook)

<a href="https://cursor.com/background-agent?bcId=bc-6b3a2ad6-a472-42a8-bd79-1820cf75ec6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6b3a2ad6-a472-42a8-bd79-1820cf75ec6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

