### PR TITLE
Enforce workflow scoping across task APIs

### DIFF
--- a/packages/ui/src/workflow-task/components/workflow-progress-bar.tsx
+++ b/packages/ui/src/workflow-task/components/workflow-progress-bar.tsx
@@ -9,6 +9,7 @@ import { FileText, CheckCircle, XCircle, Clock, Loader } from "lucide-react";
 import { cn } from "../../../lib/utils";
 
 interface WorkflowProgressBarProps {
+  workflowName: string;
   className?: string;
   /**
    * Controls auto-show/hide behavior
@@ -19,10 +20,11 @@ interface WorkflowProgressBarProps {
 }
 
 export function WorkflowProgressBar({
+  workflowName,
   className,
   mode = "auto",
 }: WorkflowProgressBarProps) {
-  const { current, total, status } = useWorkflowProgress();
+  const { current, total, status } = useWorkflowProgress(workflowName);
 
   const percentage = total > 0 ? (current / total) * 100 : 0;
 

--- a/packages/ui/src/workflow-task/hooks/use-workflow-progress.ts
+++ b/packages/ui/src/workflow-task/hooks/use-workflow-progress.ts
@@ -7,7 +7,7 @@ import { useMemo, useEffect } from "react";
 import { useTaskStore } from "./use-task-store";
 import type { WorkflowProgressState, RunStatus } from "../types";
 
-export function useWorkflowProgress(): WorkflowProgressState {
+export function useWorkflowProgress(workflowName: string): WorkflowProgressState {
   const store = useTaskStore();
   const tasks = store.tasks;
   const sync = store.sync;
@@ -15,7 +15,7 @@ export function useWorkflowProgress(): WorkflowProgressState {
   useEffect(() => {
     async function syncWithServer() {
       try {
-        await sync();
+        await sync(workflowName);
       } catch (error) {
         // eslint-disable-next-line no-console -- needed
         console.error("Failed to sync with server for progress:", error);
@@ -23,12 +23,12 @@ export function useWorkflowProgress(): WorkflowProgressState {
     }
 
     syncWithServer();
-  }, [sync]);
+  }, [sync, workflowName]);
 
   // Memoize the calculation based on tasks object
   return useMemo(() => {
     const taskArray = Object.values(tasks).filter(
-      (task) => task.status === "running"
+      (task) => task.workflowName === workflowName
     );
     const total = taskArray.length;
 
@@ -71,5 +71,5 @@ export function useWorkflowProgress(): WorkflowProgressState {
       total,
       status,
     };
-  }, [tasks]); // Only recalculate when tasks object reference changes
+  }, [tasks, workflowName]); // Only recalculate when tasks object reference changes
 }

--- a/packages/ui/src/workflow-task/types/index.ts
+++ b/packages/ui/src/workflow-task/types/index.ts
@@ -20,6 +20,7 @@ export interface WorkflowHandlerSummary {
   status: RunStatus;
   result?: unknown;
   error?: unknown;
+  workflowName: string;
 }
 
 export interface WorkflowEvent {

--- a/packages/ui/stories/workflow-progress-bar.stories.tsx
+++ b/packages/ui/stories/workflow-progress-bar.stories.tsx
@@ -25,5 +25,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  args: {},
+  args: {
+    workflowName: "test-workflow",
+  },
 };

--- a/packages/ui/stories/workflow-task-suite.stories.tsx
+++ b/packages/ui/stories/workflow-task-suite.stories.tsx
@@ -12,13 +12,15 @@ import { ApiProvider, createMockClients } from "../src/lib";
 
 // Task Trigger & Progress Component
 function TaskTriggerSection({
+  workflowName,
   onTaskClick,
   selectedTaskId,
 }: {
+  workflowName: string;
   onTaskClick: (taskId: string) => void;
   selectedTaskId: string | null;
 }) {
-  const { tasks, clearCompleted } = useWorkflowTaskList();
+  const { tasks, clearCompleted } = useWorkflowTaskList(workflowName);
   const { createTask } = useTaskStore();
   const [batchSize, setBatchSize] = useState(3);
   const [isCreatingBatch, setIsCreatingBatch] = useState(false);
@@ -61,7 +63,7 @@ function TaskTriggerSection({
 
         // Stagger the creation slightly to see the effect
         await new Promise((resolve) => setTimeout(resolve, index * 100));
-        return createTask("test-workflow", input);
+        return createTask(workflowName, input);
       });
 
       await Promise.all(promises);
@@ -119,7 +121,7 @@ function TaskTriggerSection({
       <div>
         <h3 className="text-lg font-medium mb-3">Or Create Single Task</h3>
         <WorkflowTrigger
-          workflowName="test-workflow"
+          workflowName={workflowName}
           onSuccess={() => {
             // Task completed successfully
           }}
@@ -132,7 +134,7 @@ function TaskTriggerSection({
           <h3 className="text-lg font-medium mb-3">
             Overall Progress ({tasks.length} tasks)
           </h3>
-          <WorkflowProgressBar />
+          <WorkflowProgressBar workflowName={workflowName} />
 
           {/* Enhanced Task List */}
           <div className="mt-4 space-y-2">
@@ -294,7 +296,8 @@ function TaskDetailSection({ taskId }: { taskId: string | null }) {
 
 // Internal Suite Component (uses hooks inside Provider)
 function WorkflowTaskSuiteInternal() {
-  const { tasks } = useWorkflowTaskList();
+  const workflowName = "test-workflow";
+  const { tasks } = useWorkflowTaskList(workflowName);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
 
   // Get the selected task or the most recent task for details
@@ -318,6 +321,7 @@ function WorkflowTaskSuiteInternal() {
       {/* Main Content */}
       <div className="flex h-[800px] border rounded-lg">
         <TaskTriggerSection
+          workflowName={workflowName}
           onTaskClick={setSelectedTaskId}
           selectedTaskId={selectedTaskId}
         />

--- a/packages/ui/tests/workflow-task/hooks/use-workflow-progress.test.ts
+++ b/packages/ui/tests/workflow-task/hooks/use-workflow-progress.test.ts
@@ -55,7 +55,9 @@ describe("useWorkflowProgress", () => {
 
   describe("H9: Basic functionality", () => {
     it("should start with default values", () => {
-      const { result } = renderHookWithProvider(() => useWorkflowProgress());
+      const { result } = renderHookWithProvider(() =>
+        useWorkflowProgress("test-workflow")
+      );
 
       expect(result.current.current).toBe(0);
       expect(result.current.total).toBe(0);
@@ -63,7 +65,9 @@ describe("useWorkflowProgress", () => {
     });
 
     it("should have progress properties", () => {
-      const { result } = renderHookWithProvider(() => useWorkflowProgress());
+      const { result } = renderHookWithProvider(() =>
+        useWorkflowProgress("test-workflow")
+      );
 
       expect(typeof result.current.current).toBe("number");
       expect(typeof result.current.total).toBe("number");
@@ -71,7 +75,9 @@ describe("useWorkflowProgress", () => {
     });
 
     it("should be accessible from ApiProvider context", () => {
-      const { result } = renderHookWithProvider(() => useWorkflowProgress());
+      const { result } = renderHookWithProvider(() =>
+        useWorkflowProgress("test-workflow")
+      );
 
       // Should not throw an error when called within ApiProvider
       expect(() => {
@@ -85,7 +91,9 @@ describe("useWorkflowProgress", () => {
 
   describe("H9: Hook behavior and calculations", () => {
     it("should handle empty task store efficiently", () => {
-      const { result } = renderHookWithProvider(() => useWorkflowProgress());
+      const { result } = renderHookWithProvider(() =>
+        useWorkflowProgress("test-workflow")
+      );
 
       expect(result.current.current).toBe(0);
       expect(result.current.total).toBe(0);
@@ -94,7 +102,7 @@ describe("useWorkflowProgress", () => {
 
     it("should memoize results correctly", () => {
       const { result, rerender } = renderHookWithProvider(() =>
-        useWorkflowProgress()
+        useWorkflowProgress("test-workflow")
       );
 
       const firstResult = result.current;
@@ -106,7 +114,9 @@ describe("useWorkflowProgress", () => {
     });
 
     it("should return correct structure and types", () => {
-      const { result } = renderHookWithProvider(() => useWorkflowProgress());
+      const { result } = renderHookWithProvider(() =>
+        useWorkflowProgress("test-workflow")
+      );
 
       // Verify structure
       expect(result.current).toHaveProperty("current");
@@ -127,9 +137,9 @@ describe("useWorkflowProgress", () => {
     it("should handle the useMemo dependency correctly", () => {
       // Test that the hook implementation uses useMemo correctly
       const { result } = renderHookWithProvider(() => {
-        const progress = useWorkflowProgress();
+        const progress = useWorkflowProgress("test-workflow");
         // Call multiple times to test memoization
-        const progress2 = useWorkflowProgress();
+        const progress2 = useWorkflowProgress("test-workflow");
         return { progress, progress2 };
       });
 

--- a/packages/ui/tests/workflow-task/hooks/use-workflow-task-create.test.ts
+++ b/packages/ui/tests/workflow-task/hooks/use-workflow-task-create.test.ts
@@ -49,6 +49,7 @@ describe("useWorkflowTaskCreate", () => {
   const mockTask: WorkflowHandlerSummary = {
     handler_id: "test-task-1",
     status: "running",
+    workflowName: "test-workflow",
   };
 
   beforeEach(() => {

--- a/packages/ui/tests/workflow-task/hooks/use-workflow-task-list.test.ts
+++ b/packages/ui/tests/workflow-task/hooks/use-workflow-task-list.test.ts
@@ -55,7 +55,9 @@ describe("useWorkflowTaskList", () => {
 
   describe("H3: Initial render reads persisted tasks", () => {
     it("should return empty tasks initially", () => {
-      const { result } = renderHookWithProvider(() => useWorkflowTaskList());
+      const { result } = renderHookWithProvider(() =>
+        useWorkflowTaskList("test-workflow")
+      );
 
       expect(result.current.tasks).toEqual([]);
       expect(typeof result.current.clearCompleted).toBe("function");
@@ -64,7 +66,9 @@ describe("useWorkflowTaskList", () => {
 
   describe("H4: Auto-stream for running tasks", () => {
     it("should have auto-stream functionality", () => {
-      const { result } = renderHookWithProvider(() => useWorkflowTaskList());
+      const { result } = renderHookWithProvider(() =>
+        useWorkflowTaskList("test-workflow")
+      );
 
       // Test basic functionality - tasks should be empty initially
       expect(result.current.tasks).toEqual([]);
@@ -73,7 +77,9 @@ describe("useWorkflowTaskList", () => {
 
   describe("H5: clearCompleted removes only complete/error tasks", () => {
     it("should have clearCompleted function", () => {
-      const { result } = renderHookWithProvider(() => useWorkflowTaskList());
+      const { result } = renderHookWithProvider(() =>
+        useWorkflowTaskList("test-workflow")
+      );
 
       expect(typeof result.current.clearCompleted).toBe("function");
 

--- a/packages/ui/tests/workflow-task/store/helper.test.ts
+++ b/packages/ui/tests/workflow-task/store/helper.test.ts
@@ -53,8 +53,8 @@ describe("Helper Functions Tests", () => {
       const result = await getRunningHandlers({ client: mockClient });
       expect(getHandlers).toHaveBeenCalledWith({ client: mockClient });
       expect(result).toEqual([
-        { handler_id: "h-1", status: "running" },
-        { handler_id: "h-3", status: "running" },
+        { handler_id: "h-1", status: "running", workflowName: "" },
+        { handler_id: "h-3", status: "running", workflowName: "" },
       ]);
     });
 
@@ -78,7 +78,13 @@ describe("Helper Functions Tests", () => {
         client: mockClient,
         handlerId: "h-2",
       });
-      expect(result).toEqual({ handler_id: "h-2" });
+      expect(result).toEqual({
+        handler_id: "h-2",
+        status: undefined,
+        result: undefined,
+        error: undefined,
+        workflowName: "",
+      });
     });
 
     it("throws when not found", async () => {
@@ -107,7 +113,11 @@ describe("Helper Functions Tests", () => {
         eventData: { test: "data" },
       });
 
-      expect(result).toEqual({ handler_id: "h-1", status: "running" });
+      expect(result).toEqual({
+        handler_id: "h-1",
+        status: "running",
+        workflowName: "test-workflow",
+      });
       expect(postWorkflowsByNameRunNowait).toHaveBeenCalledWith({
         client: mockClient,
         path: { name: "test-workflow" },


### PR DESCRIPTION
## Summary
- require workflow names for task store sync and cleanup operations so each workflow is isolated
- ensure handler summaries always record their workflow name and update helper utilities accordingly
- refresh workflow task tests to expect the stricter workflow scoping contract

## Testing
- pnpm --filter ui exec vitest run --project unit

------
https://chatgpt.com/codex/tasks/task_e_68cc7ac5caf8832b99afcaef25c6422e