### PR TITLE
Export createWorkflowsClient. 

### DIFF
--- a/.changeset/sweet-taxes-chew.md
+++ b/.changeset/sweet-taxes-chew.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/ui": patch
+---
+
+Export createWorkflowsClient

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -16,6 +16,8 @@ export {
   createCloudAgentClient,
   workflowsClient,
   cloudApiClient,
+  createWorkflowsClient,
+  createWorkflowsConfig,
   type WorkflowsClient,
   type CloudAgentClient,
   type CloudApiClient,


### PR DESCRIPTION
Removed the createWorkflowClient that was there for backwards compat, but the new client name was never actually published