### PR TITLE
Add index component logic and store

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -75,6 +75,11 @@
       "import": "./dist/workflows.mjs",
       "require": "./dist/workflows.cjs"
     },
+    "./indexes": {
+      "types": "./dist/indexes.d.ts",
+      "import": "./dist/indexes.mjs",
+      "require": "./dist/indexes.cjs"
+    },
     "./accordion": {
       "types": "./dist/ui/accordion.d.ts",
       "import": "./dist/ui/accordion.mjs",

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -4,6 +4,7 @@ export * from "./extracted-data";
 export * from "./file-preview";
 export * from "./item-grid";
 export * from "./workflows";
+export * from "./indexes";
 export * from "./item-count";
 export * from "./lib";
 

--- a/packages/ui/src/indexes/hooks/index.ts
+++ b/packages/ui/src/indexes/hooks/index.ts
@@ -1,0 +1,6 @@
+export { useIndexList } from "./use-index-list";
+export { useIndex } from "./use-index";
+export { useIndexProgress } from "./use-index-progress";
+export { useIndexUpsert } from "./use-index-upsert";
+export { useIndexStore } from "./use-index-store";
+

--- a/packages/ui/src/indexes/hooks/use-index-list.ts
+++ b/packages/ui/src/indexes/hooks/use-index-list.ts
@@ -1,0 +1,44 @@
+import { useEffect, useMemo, useState } from "react";
+import { useIndexStore } from "./use-index-store";
+import type { IndexSummary } from "../types";
+
+interface UseIndexListResult {
+  indexes: IndexSummary[];
+  loading: boolean;
+  error: string | null;
+  sync: () => Promise<void>;
+}
+
+export function useIndexList(): UseIndexListResult {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const store = useIndexStore();
+  const record = store.indexes;
+  const syncStore = store.sync;
+
+  useEffect(() => {
+    async function run() {
+      setLoading(true);
+      setError(null);
+      try {
+        await syncStore();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load indexes");
+      } finally {
+        setLoading(false);
+      }
+    }
+    run();
+  }, [syncStore]);
+
+  const indexes = useMemo(() => Object.values(record), [record]);
+
+  return {
+    indexes,
+    loading,
+    error,
+    sync: syncStore,
+  };
+}
+

--- a/packages/ui/src/indexes/hooks/use-index-progress.ts
+++ b/packages/ui/src/indexes/hooks/use-index-progress.ts
@@ -1,0 +1,30 @@
+import { useMemo, useEffect } from "react";
+import { useIndexStore } from "./use-index-store";
+import type { IndexProgressState, RunStatus } from "../types";
+
+export function useIndexProgress(id: string): IndexProgressState {
+  const store = useIndexStore();
+  const { indexes, refresh } = store;
+
+  useEffect(() => {
+    async function syncOnce() {
+      try {
+        await refresh(id);
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error("Failed to refresh index for progress:", error);
+      }
+    }
+    syncOnce();
+  }, [id, refresh]);
+
+  return useMemo(() => {
+    const summary = indexes[id];
+    if (!summary) {
+      return { status: "idle" as RunStatus };
+    }
+
+    return { status: summary.status };
+  }, [indexes, id]);
+}
+

--- a/packages/ui/src/indexes/hooks/use-index-store.ts
+++ b/packages/ui/src/indexes/hooks/use-index-store.ts
@@ -1,0 +1,25 @@
+import { useMemo } from "react";
+import { useCloudApiClient } from "../../lib/api-provider";
+import { createIndexStore, type IndexStoreState } from "../store/index-store";
+
+let globalStore: ReturnType<typeof createIndexStore> | null = null;
+
+export function useIndexStore(): IndexStoreState;
+export function useIndexStore<T>(selector: (state: IndexStoreState) => T): T;
+
+export function useIndexStore<T>(selector?: (state: IndexStoreState) => T) {
+  const client = useCloudApiClient();
+  const store = useMemo(() => {
+    if (!globalStore) {
+      globalStore = createIndexStore(client);
+    }
+    return globalStore;
+  }, [client]);
+
+  return selector ? store(selector) : store();
+}
+
+export function __resetIndexStore() {
+  globalStore = null;
+}
+

--- a/packages/ui/src/indexes/hooks/use-index-upsert.ts
+++ b/packages/ui/src/indexes/hooks/use-index-upsert.ts
@@ -1,0 +1,50 @@
+import { useCallback, useState } from "react";
+import { useIndexStore } from "./use-index-store";
+import type { UpsertIndexParams, IndexSummary, AddFilesParams } from "../types";
+
+interface UseIndexUpsertResult {
+  upsertIndex: (params: UpsertIndexParams) => Promise<IndexSummary>;
+  addFiles: (params: AddFilesParams) => Promise<void>;
+  isSubmitting: boolean;
+  error: Error | null;
+}
+
+export function useIndexUpsert(): UseIndexUpsertResult {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const upsertStore = useIndexStore((s) => s.upsert);
+  const addFilesStore = useIndexStore((s) => s.addFiles);
+
+  const upsertIndex = useCallback(async (params: UpsertIndexParams) => {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const summary = await upsertStore(params);
+      setIsSubmitting(false);
+      return summary;
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      setIsSubmitting(false);
+      throw error;
+    }
+  }, [upsertStore]);
+
+  const addFiles = useCallback(async (params: AddFilesParams) => {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await addFilesStore(params);
+      setIsSubmitting(false);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      setIsSubmitting(false);
+      throw error;
+    }
+  }, [addFilesStore]);
+
+  return { upsertIndex, addFiles, isSubmitting, error };
+}
+

--- a/packages/ui/src/indexes/hooks/use-index.ts
+++ b/packages/ui/src/indexes/hooks/use-index.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useIndexStore } from "./use-index-store";
+import type { IndexSummary } from "../types";
+
+interface UseIndexResult {
+  index: IndexSummary | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+export function useIndex(id: string): UseIndexResult {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const get = useIndexStore();
+  const record = get.indexes;
+  const refreshStore = get.refresh;
+
+  const index = useMemo(() => record[id] ?? null, [record, id]);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await refreshStore(id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to refresh index");
+    } finally {
+      setLoading(false);
+    }
+  }, [id, refreshStore]);
+
+  useEffect(() => {
+    if (!index) {
+      // Attempt to fetch if missing
+      void refresh();
+    }
+  }, [index, refresh]);
+
+  return { index, loading, error, refresh };
+}
+

--- a/packages/ui/src/indexes/index.ts
+++ b/packages/ui/src/indexes/index.ts
@@ -1,0 +1,8 @@
+// Types (avoid name collisions with workflows by exporting only index-specific types)
+export type { IndexSummary, IndexProgressState, UpsertIndexParams, AddFilesParams } from "./types";
+
+// Store (not exported directly; prefer hooks)
+
+// Hooks
+export { useIndexList, useIndex, useIndexProgress, useIndexUpsert, useIndexStore } from "./hooks";
+

--- a/packages/ui/src/indexes/store/helper.ts
+++ b/packages/ui/src/indexes/store/helper.ts
@@ -1,0 +1,57 @@
+import {
+  searchPipelinesApiV1PipelinesGet,
+  upsertPipelineApiV1PipelinesPut,
+  getPipelineApiV1PipelinesPipelineIdGet,
+  addFilesToPipelineApiApiV1PipelinesPipelineIdFilesPut,
+} from "llama-cloud-services/api";
+import type { IndexSummary, UpsertIndexParams, AddFilesParams } from "../types";
+
+export async function fetchPipelines(): Promise<IndexSummary[]> {
+  const resp = await searchPipelinesApiV1PipelinesGet({});
+  if (resp.error) throw resp.error;
+  const data = (resp.data?.items ?? []) as unknown[] | undefined;
+  return (data ?? []).map((p) => toIndexSummary(p as Record<string, unknown>));
+}
+
+export async function upsertPipeline(params: UpsertIndexParams): Promise<IndexSummary> {
+  const resp = await upsertPipelineApiV1PipelinesPut({
+    body: params.config as unknown,
+  });
+  if (resp.error) throw resp.error;
+  const pipeline = resp.data as unknown as Record<string, unknown> | undefined;
+  if (!pipeline) throw new Error("Empty pipeline response");
+  return toIndexSummary(pipeline);
+}
+
+export async function getPipeline(id: string): Promise<IndexSummary> {
+  const resp = await getPipelineApiV1PipelinesPipelineIdGet({ path: { pipeline_id: id } });
+  if (resp.error) throw resp.error;
+  const pipeline = resp.data as unknown as Record<string, unknown> | undefined;
+  if (!pipeline) throw new Error("Pipeline not found");
+  return toIndexSummary(pipeline);
+}
+
+export async function addFilesToPipeline(params: AddFilesParams): Promise<void> {
+  const resp = await addFilesToPipelineApiApiV1PipelinesPipelineIdFilesPut({
+    path: { pipeline_id: params.indexId },
+    body: {
+      files: params.files,
+    } as unknown,
+  });
+  if (resp.error) throw resp.error;
+}
+
+function toIndexSummary(p: Record<string, unknown>): IndexSummary {
+  const pAny = p as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  const rawStatus = (pAny?.status as string | undefined) ?? "idle";
+  const status = (rawStatus.toLowerCase?.() as IndexSummary["status"]) || "idle";
+  return {
+    id: String(pAny.id ?? pAny.pipeline_id ?? ""),
+    name: pAny.name ?? undefined,
+    status: status,
+    createdAt: pAny.created_at as string | undefined,
+    updatedAt: pAny.updated_at as string | undefined,
+    raw: p,
+  };
+}
+

--- a/packages/ui/src/indexes/store/index-store.ts
+++ b/packages/ui/src/indexes/store/index-store.ts
@@ -1,0 +1,65 @@
+import { create } from "zustand";
+import type { CloudApiClient } from "../../lib/clients";
+import type { IndexSummary, UpsertIndexParams, AddFilesParams } from "../types";
+import {
+  fetchPipelines,
+  upsertPipeline,
+  getPipeline,
+  addFilesToPipeline,
+} from "./helper";
+
+export interface IndexStoreState {
+  indexes: Record<string, IndexSummary>;
+
+  // CRUD
+  sync(): Promise<void>;
+  refresh(id: string): Promise<void>;
+  upsert(params: UpsertIndexParams): Promise<IndexSummary>;
+  addFiles(params: AddFilesParams): Promise<void>;
+}
+
+export const createIndexStore = (_client: CloudApiClient) =>
+  create<IndexStoreState>()((set, get) => ({
+    indexes: {},
+
+    sync: async () => {
+      try {
+        const list = await fetchPipelines();
+        set({
+          indexes: Object.fromEntries(list.map((i) => [i.id, i])),
+        });
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error("Failed to sync indexes:", error);
+      }
+    },
+
+    refresh: async (id: string) => {
+      try {
+        const summary = await getPipeline(id);
+        set((state) => ({ indexes: { ...state.indexes, [id]: summary } }));
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error("Failed to refresh index:", id, error);
+      }
+    },
+
+    upsert: async (params: UpsertIndexParams) => {
+      const summary = await upsertPipeline(params);
+      set((state) => ({ indexes: { ...state.indexes, [summary.id]: summary } }));
+      return summary;
+    },
+
+    addFiles: async (params: AddFilesParams) => {
+      await addFilesToPipeline(params);
+      // Optionally refresh status after add
+      try {
+        const summary = await getPipeline(params.indexId);
+        set((state) => ({ indexes: { ...state.indexes, [summary.id]: summary } }));
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error("Failed to refresh after addFiles:", error);
+      }
+    },
+  }));
+

--- a/packages/ui/src/indexes/types/index.ts
+++ b/packages/ui/src/indexes/types/index.ts
@@ -1,0 +1,41 @@
+// ===== Index (Pipeline) Types =====
+
+export type JSONValue =
+  | null
+  | string
+  | number
+  | boolean
+  | { [key: string]: JSONValue }
+  | Array<JSONValue>;
+
+export type RunStatus = "idle" | "running" | "complete" | "failed";
+
+export interface IndexSummary {
+  id: string;
+  name?: string;
+  status: RunStatus;
+  createdAt?: string | Date;
+  updatedAt?: string | Date;
+  // Store original server payload for advanced consumers
+  raw?: unknown;
+}
+
+export interface IndexProgressState {
+  status: RunStatus;
+}
+
+export interface UpsertIndexParams {
+  // Free-form config passed directly to the API
+  // Callers should provide valid pipeline config per llama-cloud-services
+  config: { [key: string]: JSONValue };
+}
+
+export interface AddFilesParams {
+  indexId: string;
+  files: Array<{
+    file_id: string;
+    // Optional metadata forwarded to API when supported
+    custom_metadata?: { [key: string]: JSONValue };
+  }>;
+}
+


### PR DESCRIPTION
Add `indexes` module with hooks and a Zustand store to provide programmatic access to LlamaIndex pipelines via `llama-cloud-services` API, following the `workflows` pattern.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3d4a730-d059-4dc7-b9ba-fd37c6cf5c6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b3d4a730-d059-4dc7-b9ba-fd37c6cf5c6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

