### PR TITLE
Truncate long file names in upload modal

### DIFF
--- a/packages/ui/src/file-uploader/file-uploader.tsx
+++ b/packages/ui/src/file-uploader/file-uploader.tsx
@@ -292,7 +292,7 @@ export function FileUploader({
                       >
                         <div className="flex items-center space-x-2 min-w-0 flex-1">
                           <Upload className="h-3 w-3 text-muted-foreground flex-shrink-0" />
-                          <span className="text-sm font-medium truncate">
+                          <span className="text-sm font-medium truncate block min-w-0 flex-1" title={file.name}>
                             {file.name}
                           </span>
                           <span className="text-xs text-muted-foreground flex-shrink-0">

--- a/packages/ui/src/file-uploader/upload-progress.tsx
+++ b/packages/ui/src/file-uploader/upload-progress.tsx
@@ -158,7 +158,7 @@ function FileProgressItem({
     // Compact view for many files
     return (
       <div className="space-y-1">
-        <div className="flex items-center gap-2 text-xs">
+        <div className="flex items-center gap-2 text-xs min-w-0">
           <div
             className={`w-2 h-2 rounded-full flex-shrink-0 ${
               status === "error"
@@ -170,7 +170,7 @@ function FileProgressItem({
                     : "bg-primary animate-pulse"
             }`}
           />
-          <span className="font-medium truncate flex-1" title={file.name}>
+          <span className="font-medium truncate flex-1 min-w-0" title={file.name}>
             {file.name}
           </span>
           <span className="text-muted-foreground">
@@ -194,8 +194,8 @@ function FileProgressItem({
   // Full view for fewer files
   return (
     <div className="space-y-2">
-      <div className="flex items-center justify-between text-sm">
-        <span className="font-medium truncate flex-1" title={file.name}>
+      <div className="flex items-center justify-between text-sm min-w-0">
+        <span className="font-medium truncate flex-1 min-w-0" title={file.name}>
           {file.name}
         </span>
         <span className="text-muted-foreground ml-2">


### PR DESCRIPTION
Truncate long filenames with an ellipsis in the file upload modal and progress components to prevent UI overflow.

---
Linear Issue: [LI-3738](https://linear.app/llamaindex/issue/LI-3738/handle-long-file-names-better)

<a href="https://cursor.com/background-agent?bcId=bc-c21fa126-6aa9-4b8c-a481-e0404d03315d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c21fa126-6aa9-4b8c-a481-e0404d03315d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

