### PR TITLE
Add handler existence field to hook

### DIFF
--- a/packages/ui/tests/workflows/hooks/use-workflow-handler.test.ts
+++ b/packages/ui/tests/workflows/hooks/use-workflow-handler.test.ts
@@ -131,6 +131,7 @@ describe("useWorkflowTask", () => {
       );
 
       // Force rejection for this check
+      (getExistingHandler as unknown as vi.Mock).mockReset();
       (getExistingHandler as unknown as vi.Mock).mockRejectedValueOnce(
         new Error("not found")
       );
@@ -149,6 +150,7 @@ describe("useWorkflowTask", () => {
         "../../../src/workflows/store/helper"
       );
 
+      (getExistingHandler as unknown as vi.Mock).mockReset();
       (getExistingHandler as unknown as vi.Mock).mockResolvedValueOnce({
         handler_id: "ok-123",
         status: "running",


### PR DESCRIPTION
Add a `notFound` field to the `useWorkflowHandler` hook result to indicate when a handler ID no longer exists on the server, addressing LI-3709.

---
Linear Issue: [LI-3709](https://linear.app/llamaindex/issue/LI-3709/need-a-better-way-to-detect-that-a-handler-id-no-longer-exists-deleted)

<a href="https://cursor.com/background-agent?bcId=bc-15258f2a-ac57-4ae9-93be-6ecbbf8fe335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-15258f2a-ac57-4ae9-93be-6ecbbf8fe335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

