### PR TITLE
fix: pass through internal events flag to un-break workflow-debugger

### DIFF
--- a/packages/ui/src/workflows/hooks/use-workflow-handler.ts
+++ b/packages/ui/src/workflows/hooks/use-workflow-handler.ts
@@ -15,7 +15,12 @@ interface UseWorkflowHandlerResult {
 
 export function useWorkflowHandler(
   handlerId: string,
-  autoStream: boolean = true
+  autoStream: boolean = true,
+  {
+    includeInternal = false,
+  }: {
+    includeInternal?: boolean;
+  } = {}
 ): UseWorkflowHandlerResult {
   const client = useWorkflowsClient();
   const handler = useHandlerStore((state) => state.handlers[handlerId] || null);
@@ -36,7 +41,7 @@ export function useWorkflowHandler(
     if (handler.status !== "running") return;
 
     // Use store's subscribe method
-    subscribe(handlerId);
+    subscribe(handlerId, { includeInternal: includeInternal });
 
     // Cleanup when handler is no longer running or component unmounts
     return () => {
@@ -44,7 +49,7 @@ export function useWorkflowHandler(
         unsubscribe(handlerId);
       }
     };
-  }, [handlerId, handler, autoStream, subscribe, unsubscribe]);
+  }, [handlerId, handler, autoStream, subscribe, unsubscribe, includeInternal]);
 
   const stopStreaming = useCallback(() => {
     unsubscribe(handlerId);

--- a/packages/ui/src/workflows/store/helper.ts
+++ b/packages/ui/src/workflows/store/helper.ts
@@ -83,6 +83,7 @@ export function fetchHandlerEvents<E extends WorkflowEvent>(
     client: Client;
     handlerId: string;
     signal?: AbortSignal;
+    includeInternal?: boolean;
   },
   callback?: StreamingEventCallback<E>
 ): { promise: Promise<E[]>; unsubscribe: () => void } {
@@ -123,8 +124,13 @@ export function fetchHandlerEvents<E extends WorkflowEvent>(
       /\/$/,
       ""
     );
+    const urlParams = new URLSearchParams();
+    urlParams.set("sse", "true");
+    if (params.includeInternal) {
+      urlParams.set("include_internal", "true");
+    }
     const eventSource = new EventSource(
-      `${baseUrl}/events/${encodeURIComponent(params.handlerId)}?sse=true`,
+      `${baseUrl}/events/${encodeURIComponent(params.handlerId)}?${urlParams.toString()}`,
       {
         withCredentials: true,
       }

--- a/packages/workflow-debugger/src/components/run-details-panel.tsx
+++ b/packages/workflow-debugger/src/components/run-details-panel.tsx
@@ -37,7 +37,9 @@ export function RunDetailsPanel({
   handlerId,
   selectedWorkflow,
 }: RunDetailsPanelProps) {
-  const { handler, events } = useWorkflowHandler(handlerId ?? "", !!handlerId);
+  const { handler, events } = useWorkflowHandler(handlerId ?? "", !!handlerId, {
+    includeInternal: true,
+  });
   const workflowsClient = useWorkflowsClient();
   const [compactJson, setCompactJson] = useState(false);
   const [hideInternal, setHideInternal] = useState(true);


### PR DESCRIPTION
Adds configuration to toggle internal events in a subscription. Once enabled, it stays on until unsubscrived