### PR TITLE
Fix boolean field editing in nested structures

### DIFF
--- a/packages/ui/src/extracted-data/list-renderer/list-renderer.tsx
+++ b/packages/ui/src/extracted-data/list-renderer/list-renderer.tsx
@@ -6,7 +6,7 @@ import {
   getArrayItemDefaultValue,
 } from "./list-renderer-utils";
 import { Plus, Trash2 } from "lucide-react";
-import { PrimitiveType, toPrimitiveType } from "../primitive-validation";
+import { PrimitiveType, toPrimitiveType, inferTypeFromValue } from "../primitive-validation";
 import type { FieldSchemaMetadata } from "../schema-reconciliation";
 import type { PrimitiveValue, RendererMetadata } from "../types";
 import type { ExtractedFieldMetadata } from "llama-cloud-services/beta/agent";
@@ -75,6 +75,12 @@ export function ListRenderer<S extends PrimitiveValue>({
 
     if (itemMetadata?.schemaType) {
       return toPrimitiveType(itemMetadata.schemaType);
+    }
+
+    // When schema metadata is not available, infer type from the first value
+    // This is critical for boolean fields to be editable as checkboxes
+    if (data && data.length > 0) {
+      return inferTypeFromValue(data[0]);
     }
 
     return PrimitiveType.STRING; // Default fallback

--- a/packages/ui/src/extracted-data/primitive-validation.ts
+++ b/packages/ui/src/extracted-data/primitive-validation.ts
@@ -80,3 +80,25 @@ export function getDefaultPrimitiveValue(
       return "";
   }
 }
+
+/**
+ * Infer PrimitiveType from a runtime value
+ * This is used as a fallback when schema metadata is not available
+ */
+export function inferTypeFromValue(value: unknown): PrimitiveType {
+  if (value === null || value === undefined) {
+    return PrimitiveType.STRING;
+  }
+
+  const valueType = typeof value;
+  
+  switch (valueType) {
+    case "boolean":
+      return PrimitiveType.BOOLEAN;
+    case "number":
+      return PrimitiveType.NUMBER;
+    case "string":
+    default:
+      return PrimitiveType.STRING;
+  }
+}

--- a/packages/ui/src/extracted-data/table-renderer/table-renderer.tsx
+++ b/packages/ui/src/extracted-data/table-renderer/table-renderer.tsx
@@ -30,7 +30,7 @@ import {
 } from "../metadata-path-utils";
 import { findExtractedFieldMetadata } from "../metadata-lookup";
 import { Plus, Trash2 } from "lucide-react";
-import { PrimitiveType, toPrimitiveType } from "../primitive-validation";
+import { toPrimitiveType, inferTypeFromValue } from "../primitive-validation";
 import type { PrimitiveValue, JsonValue, JsonObject } from "../types";
 import { DataPagination } from "../data-pagination";
 
@@ -396,9 +396,11 @@ export function TableRenderer<Row extends JsonObject>({
                   fieldKeyPath,
                   effectiveMetadata.schema
                 );
+                // When schema metadata is not available, infer type from the actual value
+                // This is critical for boolean fields to be editable as checkboxes
                 const expectedType = fieldInfo?.schemaType
                   ? toPrimitiveType(fieldInfo.schemaType)
-                  : PrimitiveType.STRING;
+                  : inferTypeFromValue(value);
                 const isRequired = fieldInfo?.isRequired || false;
 
                 return (

--- a/packages/ui/tests/extracted-data/boolean-field-editing.test.tsx
+++ b/packages/ui/tests/extracted-data/boolean-field-editing.test.tsx
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TableRenderer } from "@/src/extracted-data/table-renderer";
+import { ListRenderer } from "@/src/extracted-data/list-renderer";
+import { EditableField } from "@/src/extracted-data/editable-field";
+import { PrimitiveType, inferTypeFromValue } from "@/src/extracted-data/primitive-validation";
+
+describe("Boolean Field Editing", () => {
+  describe("inferTypeFromValue", () => {
+    it("should infer BOOLEAN from boolean values", () => {
+      expect(inferTypeFromValue(true)).toBe(PrimitiveType.BOOLEAN);
+      expect(inferTypeFromValue(false)).toBe(PrimitiveType.BOOLEAN);
+    });
+
+    it("should infer NUMBER from number values", () => {
+      expect(inferTypeFromValue(42)).toBe(PrimitiveType.NUMBER);
+      expect(inferTypeFromValue(0)).toBe(PrimitiveType.NUMBER);
+      expect(inferTypeFromValue(-10.5)).toBe(PrimitiveType.NUMBER);
+    });
+
+    it("should infer STRING from string values", () => {
+      expect(inferTypeFromValue("hello")).toBe(PrimitiveType.STRING);
+      expect(inferTypeFromValue("")).toBe(PrimitiveType.STRING);
+      expect(inferTypeFromValue("true")).toBe(PrimitiveType.STRING);
+    });
+
+    it("should default to STRING for null/undefined", () => {
+      expect(inferTypeFromValue(null)).toBe(PrimitiveType.STRING);
+      expect(inferTypeFromValue(undefined)).toBe(PrimitiveType.STRING);
+    });
+  });
+
+  describe("EditableField with boolean type", () => {
+    it("should render boolean field with select dropdown", () => {
+      const { container } = render(
+        <EditableField
+          value={true}
+          onSave={() => {}}
+          expectedType={PrimitiveType.BOOLEAN}
+        />
+      );
+
+      // Check that the field displays the boolean value
+      expect(container).toHaveTextContent("true");
+    });
+
+    it("should handle false boolean values", () => {
+      const { container } = render(
+        <EditableField
+          value={false}
+          onSave={() => {}}
+          expectedType={PrimitiveType.BOOLEAN}
+        />
+      );
+
+      // Check that the field displays the boolean value
+      expect(container).toHaveTextContent("false");
+    });
+  });
+
+  describe("TableRenderer with boolean fields", () => {
+    it("should infer boolean type for boolean fields without schema metadata", () => {
+      const data = [
+        { is_tax: false, line_total: 22.68, description: "RESORT FEE" },
+        { is_tax: true, line_total: 27.96, description: "TAX2" },
+        { is_tax: false, line_total: 51.02, description: "ROOM CHARGE" },
+      ];
+
+      const { container } = render(
+        <TableRenderer
+          data={data}
+          onUpdate={() => {}}
+          editable={true}
+        />
+      );
+
+      // Check that boolean values are rendered correctly
+      expect(container).toHaveTextContent("false");
+      expect(container).toHaveTextContent("true");
+    });
+
+    it("should handle nested boolean fields", () => {
+      const data = [
+        {
+          item: {
+            is_active: true,
+            is_verified: false,
+          },
+        },
+      ];
+
+      const { container } = render(
+        <TableRenderer
+          data={data}
+          onUpdate={() => {}}
+          editable={true}
+        />
+      );
+
+      // Check that nested boolean values are rendered
+      expect(container).toHaveTextContent("true");
+      expect(container).toHaveTextContent("false");
+    });
+
+    it("should use schema metadata when available", () => {
+      const data = [
+        { is_tax: false, line_total: 22.68 },
+      ];
+
+      const metadata = {
+        schema: {
+          "line_items.*.is_tax": {
+            isRequired: false,
+            isOptional: true,
+            schemaType: "boolean",
+            title: "Is Tax",
+            wasMissing: false,
+          },
+        },
+        extracted: {},
+      };
+
+      const { container } = render(
+        <TableRenderer
+          data={data}
+          onUpdate={() => {}}
+          keyPath={["line_items"]}
+          metadata={metadata}
+          editable={true}
+        />
+      );
+
+      expect(container).toHaveTextContent("false");
+    });
+  });
+
+  describe("ListRenderer with boolean fields", () => {
+    it("should infer boolean type for boolean list items without schema metadata", () => {
+      const data = [true, false, true, false];
+
+      const { container } = render(
+        <ListRenderer
+          data={data}
+          onUpdate={() => {}}
+          editable={true}
+        />
+      );
+
+      // Check that boolean values are rendered correctly
+      const trueElements = screen.getAllByText("true");
+      const falseElements = screen.getAllByText("false");
+      
+      expect(trueElements.length).toBeGreaterThan(0);
+      expect(falseElements.length).toBeGreaterThan(0);
+    });
+
+    it("should use schema metadata when available", () => {
+      const data = [true, false];
+
+      const metadata = {
+        schema: {
+          "flags.*": {
+            isRequired: false,
+            isOptional: true,
+            schemaType: "boolean",
+            title: "Flag",
+            wasMissing: false,
+          },
+        },
+        extracted: {},
+      };
+
+      const { container } = render(
+        <ListRenderer
+          data={data}
+          onUpdate={() => {}}
+          keyPath={["flags"]}
+          metadata={metadata}
+          editable={true}
+        />
+      );
+
+      expect(container).toHaveTextContent("true");
+      expect(container).toHaveTextContent("false");
+    });
+  });
+
+  describe("Issue LI-3766: Boolean fields in nested structures", () => {
+    it("should prevent string input for boolean fields in line_items", () => {
+      // This is the exact scenario from the issue
+      const lineItems = [
+        {
+          is_tax: false,
+          line_total: 22.68,
+          description: "RESORT FEE (11/25/18, Ref: 434289101289)",
+        },
+        {
+          is_tax: true,
+          line_total: 27.96,
+          description: "TAX2 for ROOM CHARGE (11/25/18, Ref: 434289113392)",
+        },
+      ];
+
+      const { container } = render(
+        <TableRenderer
+          data={lineItems}
+          onUpdate={() => {}}
+          keyPath={["line_items"]}
+          editable={true}
+        />
+      );
+
+      // Verify that the component renders successfully
+      expect(container).toBeTruthy();
+      
+      // Verify that boolean values are displayed correctly
+      expect(container).toHaveTextContent("false");
+      expect(container).toHaveTextContent("true");
+      
+      // The key fix: When clicking to edit, it should show a select dropdown
+      // with only "true" and "false" options, not allow arbitrary string input
+      // This is verified implicitly - if expectedType is BOOLEAN,
+      // EditableField will render a Select component, not a text input
+    });
+  });
+});

--- a/packages/ui/tests/extracted-data/primitive-validation.test.ts
+++ b/packages/ui/tests/extracted-data/primitive-validation.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  PrimitiveType,
+  toPrimitiveType,
+  convertPrimitiveValue,
+  getDefaultPrimitiveValue,
+  inferTypeFromValue,
+} from "@/src/extracted-data/primitive-validation";
+
+describe("primitive-validation", () => {
+  describe("toPrimitiveType", () => {
+    it("should convert schema types to PrimitiveType enum", () => {
+      expect(toPrimitiveType("string")).toBe(PrimitiveType.STRING);
+      expect(toPrimitiveType("number")).toBe(PrimitiveType.NUMBER);
+      expect(toPrimitiveType("boolean")).toBe(PrimitiveType.BOOLEAN);
+    });
+
+    it("should default to STRING for unknown types", () => {
+      expect(toPrimitiveType("unknown")).toBe(PrimitiveType.STRING);
+      expect(toPrimitiveType("object")).toBe(PrimitiveType.STRING);
+      expect(toPrimitiveType("array")).toBe(PrimitiveType.STRING);
+    });
+  });
+
+  describe("convertPrimitiveValue", () => {
+    it("should convert string values correctly", () => {
+      expect(convertPrimitiveValue("hello", PrimitiveType.STRING)).toBe("hello");
+      expect(convertPrimitiveValue("", PrimitiveType.STRING)).toBe("");
+    });
+
+    it("should convert number values correctly", () => {
+      expect(convertPrimitiveValue("42", PrimitiveType.NUMBER)).toBe(42);
+      expect(convertPrimitiveValue("0", PrimitiveType.NUMBER)).toBe(0);
+      expect(convertPrimitiveValue("-10.5", PrimitiveType.NUMBER)).toBe(-10.5);
+    });
+
+    it("should handle empty number inputs based on required flag", () => {
+      expect(convertPrimitiveValue("", PrimitiveType.NUMBER, false)).toBe(null);
+      expect(convertPrimitiveValue("", PrimitiveType.NUMBER, true)).toBe("");
+    });
+
+    it("should convert boolean values correctly", () => {
+      expect(convertPrimitiveValue("true", PrimitiveType.BOOLEAN)).toBe(true);
+      expect(convertPrimitiveValue("false", PrimitiveType.BOOLEAN)).toBe(false);
+    });
+  });
+
+  describe("getDefaultPrimitiveValue", () => {
+    it("should return empty string for optional fields", () => {
+      expect(getDefaultPrimitiveValue(PrimitiveType.STRING, false)).toBe("");
+      expect(getDefaultPrimitiveValue(PrimitiveType.NUMBER, false)).toBe("");
+      expect(getDefaultPrimitiveValue(PrimitiveType.BOOLEAN, false)).toBe("");
+    });
+
+    it("should return appropriate defaults for required fields", () => {
+      expect(getDefaultPrimitiveValue(PrimitiveType.STRING, true)).toBe("");
+      expect(getDefaultPrimitiveValue(PrimitiveType.NUMBER, true)).toBe(0);
+      expect(getDefaultPrimitiveValue(PrimitiveType.BOOLEAN, true)).toBe(false);
+    });
+  });
+
+  describe("inferTypeFromValue", () => {
+    it("should infer BOOLEAN type from boolean values", () => {
+      expect(inferTypeFromValue(true)).toBe(PrimitiveType.BOOLEAN);
+      expect(inferTypeFromValue(false)).toBe(PrimitiveType.BOOLEAN);
+    });
+
+    it("should infer NUMBER type from number values", () => {
+      expect(inferTypeFromValue(0)).toBe(PrimitiveType.NUMBER);
+      expect(inferTypeFromValue(42)).toBe(PrimitiveType.NUMBER);
+      expect(inferTypeFromValue(-10.5)).toBe(PrimitiveType.NUMBER);
+      expect(inferTypeFromValue(3.14159)).toBe(PrimitiveType.NUMBER);
+    });
+
+    it("should infer STRING type from string values", () => {
+      expect(inferTypeFromValue("hello")).toBe(PrimitiveType.STRING);
+      expect(inferTypeFromValue("")).toBe(PrimitiveType.STRING);
+      expect(inferTypeFromValue("42")).toBe(PrimitiveType.STRING);
+      expect(inferTypeFromValue("true")).toBe(PrimitiveType.STRING);
+    });
+
+    it("should default to STRING for null and undefined", () => {
+      expect(inferTypeFromValue(null)).toBe(PrimitiveType.STRING);
+      expect(inferTypeFromValue(undefined)).toBe(PrimitiveType.STRING);
+    });
+
+    it("should handle edge cases", () => {
+      // NaN is a number type in JavaScript
+      expect(inferTypeFromValue(NaN)).toBe(PrimitiveType.NUMBER);
+      // Infinity is also a number
+      expect(inferTypeFromValue(Infinity)).toBe(PrimitiveType.NUMBER);
+      expect(inferTypeFromValue(-Infinity)).toBe(PrimitiveType.NUMBER);
+    });
+  });
+});


### PR DESCRIPTION
Infer primitive types for extracted data fields when schema metadata is missing to correctly render boolean fields as dropdowns.

Previously, boolean fields in nested structures defaulted to string inputs when schema metadata was unavailable, allowing invalid values. This fix introduces runtime type inference to ensure appropriate UI components (e.g., boolean dropdowns) are used, preventing invalid data entry.

---
Linear Issue: [LI-3766](https://linear.app/llamaindex/issue/LI-3766/boolean-extracted-data-fields)

<a href="https://cursor.com/background-agent?bcId=bc-1b27bb79-bbe9-417c-909d-a054ef6d31e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1b27bb79-bbe9-417c-909d-a054ef6d31e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

