### PR TITLE
feat(ui): resume subscribeToEvents from last-seen sequence

### DIFF
--- a/.changeset/handler-subscribe-cursor.md
+++ b/.changeset/handler-subscribe-cursor.md
@@ -2,9 +2,4 @@
 "@llamaindex/ui": minor
 ---
 
-`subscribeToEvents` now auto-resumes at the last-seen sequence number after
-unmount/remount, so no events are dropped in the gap. Adds an `afterSequence`
-option for explicit cursor control (number, `"now"`, or `-1` to replay from
-the beginning). The legacy `(callbacks, includeInternal)` boolean form still
-works; prefer `(callbacks, { includeInternal })`. Server 204 "handler drained"
-responses now cleanly terminate the subscriber instead of hanging.
+`subscribeToEvents` now auto-resumes at the last-seen sequence number from workflow event stream after unmount/remount, so no events are dropped in the gap.

--- a/.changeset/handler-subscribe-cursor.md
+++ b/.changeset/handler-subscribe-cursor.md
@@ -1,0 +1,10 @@
+---
+"@llamaindex/ui": minor
+---
+
+`subscribeToEvents` now auto-resumes at the last-seen sequence number after
+unmount/remount, so no events are dropped in the gap. Adds an `afterSequence`
+option for explicit cursor control (number, `"now"`, or `-1` to replay from
+the beginning). The legacy `(callbacks, includeInternal)` boolean form still
+works; prefer `(callbacks, { includeInternal })`. Server 204 "handler drained"
+responses now cleanly terminate the subscriber instead of hanging.

--- a/packages/ui/src/workflows/components/handler-details.tsx
+++ b/packages/ui/src/workflows/components/handler-details.tsx
@@ -42,7 +42,7 @@ export function HandlerDetails({ handlerId, onBack }: HandlerDetailsProps) {
             setIsStreaming(false);
           },
         },
-        true
+        { includeInternal: true }
       );
 
       return () => disconnect();

--- a/packages/ui/src/workflows/index.ts
+++ b/packages/ui/src/workflows/index.ts
@@ -6,6 +6,7 @@ export * from "./store/workflow-event";
 // Store classes
 export type {
   HandlerState,
+  SubscribeToEventsOptions,
   createState as createHandlerState,
   createActions as createHandlerActions,
 } from "./store/handler";

--- a/packages/ui/src/workflows/store/handler.ts
+++ b/packages/ui/src/workflows/store/handler.ts
@@ -169,100 +169,111 @@ export function createActions(state: HandlerState, client: Client) {
         state.loading = false;
       }
     },
-    /**
-     * Subscribe to the SSE event stream for this handler.
-     *
-     * Passing a boolean as the second argument is deprecated — use
-     * `{ includeInternal }` instead. When no `afterSequence` is provided the
-     * client auto-resumes from the last event id observed for this handler
-     * (within the current session) so that tearing down and re-subscribing
-     * doesn't drop events emitted in between.
-     */
-    subscribeToEvents(
-      callbacks?: StreamSubscriber<WorkflowEvent>,
-      optionsOrIncludeInternal?: SubscribeToEventsOptions | boolean
-    ): StreamOperation<WorkflowEvent> {
-      if (!state.handler_id) {
-        throw new Error("Handler ID is not yet initialized");
-      }
-      const options: SubscribeToEventsOptions =
-        typeof optionsOrIncludeInternal === "boolean"
-          ? { includeInternal: optionsOrIncludeInternal }
-          : (optionsOrIncludeInternal ?? {});
-      const streamKey = `handler:${state.handler_id}`;
+  };
 
-      // Convert callback to SharedStreamingManager subscriber
-      // Be aware that all datetimes below are not synced with server, only client local state update
-      const subscriber: StreamSubscriber<WorkflowEvent> = {
-        onStart: () => {
-          state.status = "running";
-          callbacks?.onStart?.();
-        },
-        onData: (event) => {
-          state.updated_at = new Date();
-          callbacks?.onData?.(event);
-        },
-        onError: (error) => {
-          state.status = "failed";
-          state.completed_at = new Date();
-          state.updated_at = new Date();
-          state.error = error.message;
-          callbacks?.onError?.(error);
-        },
-        onSuccess: (events) => {
-          state.status = "completed";
-          state.completed_at = new Date();
-          state.updated_at = new Date();
-          state.result = events[events.length - 1] as StopEvent;
-          callbacks?.onSuccess?.(events);
-        },
-        onComplete: () => {
-          state.completed_at = new Date();
-          state.updated_at = new Date();
-          callbacks?.onComplete?.();
-        },
-      };
+  /**
+   * Subscribe to the SSE event stream for this handler.
+   *
+   * When no `afterSequence` is provided the client auto-resumes from the last
+   * event id observed for this handler (within the current session) so that
+   * tearing down and re-subscribing doesn't drop events emitted in between.
+   */
+  function subscribeToEvents(
+    callbacks?: StreamSubscriber<WorkflowEvent>,
+    options?: SubscribeToEventsOptions
+  ): StreamOperation<WorkflowEvent>;
+  /**
+   * @deprecated Pass `{ includeInternal }` as the second argument instead.
+   */
+  function subscribeToEvents(
+    callbacks: StreamSubscriber<WorkflowEvent> | undefined,
+    includeInternal: boolean
+  ): StreamOperation<WorkflowEvent>;
+  function subscribeToEvents(
+    callbacks?: StreamSubscriber<WorkflowEvent>,
+    optionsOrIncludeInternal?: SubscribeToEventsOptions | boolean
+  ): StreamOperation<WorkflowEvent> {
+    if (!state.handler_id) {
+      throw new Error("Handler ID is not yet initialized");
+    }
+    const options: SubscribeToEventsOptions =
+      typeof optionsOrIncludeInternal === "boolean"
+        ? { includeInternal: optionsOrIncludeInternal }
+        : (optionsOrIncludeInternal ?? {});
+    const streamKey = `handler:${state.handler_id}`;
 
-      const canceler = async () => {
-        await postHandlersByHandlerIdCancel({
-          client: client,
-          path: {
-            handler_id: state.handler_id,
-          },
-        });
-      };
+    // Convert callback to SharedStreamingManager subscriber
+    // Be aware that all datetimes below are not synced with server, only client local state update
+    const subscriber: StreamSubscriber<WorkflowEvent> = {
+      onStart: () => {
+        state.status = "running";
+        callbacks?.onStart?.();
+      },
+      onData: (event) => {
+        state.updated_at = new Date();
+        callbacks?.onData?.(event);
+      },
+      onError: (error) => {
+        state.status = "failed";
+        state.completed_at = new Date();
+        state.updated_at = new Date();
+        state.error = error.message;
+        callbacks?.onError?.(error);
+      },
+      onSuccess: (events) => {
+        state.status = "completed";
+        state.completed_at = new Date();
+        state.updated_at = new Date();
+        state.result = events[events.length - 1] as StopEvent;
+        callbacks?.onSuccess?.(events);
+      },
+      onComplete: () => {
+        state.completed_at = new Date();
+        state.updated_at = new Date();
+        callbacks?.onComplete?.();
+      },
+    };
 
-      const resolvedAfterSequence = resolveAfterSequence(
-        options.afterSequence,
-        handlerCursors.get(state.handler_id)
+    const canceler = async () => {
+      await postHandlersByHandlerIdCancel({
+        client: client,
+        path: {
+          handler_id: state.handler_id,
+        },
+      });
+    };
+
+    const resolvedAfterSequence = resolveAfterSequence(
+      options.afterSequence,
+      handlerCursors.get(state.handler_id)
+    );
+
+    const { promise, unsubscribe, disconnect, cancel } =
+      workflowStreamingManager.subscribe(
+        streamKey,
+        subscriber,
+        async (subscriber, signal) => {
+          return streamByEventSource(
+            {
+              client: client,
+              handlerId: state.handler_id,
+              includeInternal: options.includeInternal,
+              afterSequence: resolvedAfterSequence,
+              abortSignal: signal,
+            },
+            subscriber,
+            fullActions,
+            state
+          );
+        },
+        canceler
       );
 
-      // Use SharedStreamingManager to handle the streaming with deduplication
-      const { promise, unsubscribe, disconnect, cancel } =
-        workflowStreamingManager.subscribe(
-          streamKey,
-          subscriber,
-          async (subscriber, signal) => {
-            return streamByEventSource(
-              {
-                client: client,
-                handlerId: state.handler_id,
-                includeInternal: options.includeInternal,
-                afterSequence: resolvedAfterSequence,
-                abortSignal: signal,
-              },
-              subscriber,
-              actions,
-              state
-            );
-          },
-          canceler
-        );
+    return { promise, unsubscribe, disconnect, cancel };
+  }
 
-      return { promise, unsubscribe, disconnect, cancel };
-    },
-  };
-  return actions;
+  const fullActions = { ...actions, subscribeToEvents };
+  return fullActions;
 }
 
 function resolveAfterSequence(
@@ -328,10 +339,12 @@ function streamByEventSource(
       } else if (state.status === "cancelled") {
         callbacks.onCancel?.();
       } else {
-        // Fall back to onSuccess for unknown terminal states so subscribers
-        // don't hang. This covers drained handlers where the server closed
-        // the stream (204) before we observed a StopEvent.
-        callbacks.onSuccess?.(accumulatedEvents);
+        // Stream closed but the handler isn't in a terminal state. Shouldn't
+        // happen in practice; surface as an error rather than silently
+        // succeeding.
+        callbacks.onError?.(
+          new Error(`Stream closed while handler status was ${state.status}`)
+        );
       }
       resolve(accumulatedEvents);
     };
@@ -356,16 +369,19 @@ function streamByEventSource(
       }
     });
     eventSource.addEventListener("error", (event) => {
-      // The Python server closes the SSE connection by surfacing an `error`
-      // event with readyState === CLOSED, including for the 204 "handler
-      // drained" response. Treat that as a clean close and flush whatever we
-      // accumulated so re-subscribes to a drained handler don't hang.
-      logger.warn("[streamByEventSource] error", event);
       if (settled) return;
+      // The workflow server closes the SSE connection by surfacing an `error`
+      // event with readyState === CLOSED, including for the 204 "handler
+      // drained" response. That's a clean close — flush what we have and
+      // don't log, otherwise every drained re-subscribe spams a warning.
+      // A non-CLOSED readyState means the browser will auto-reconnect; log
+      // because that's genuinely unexpected here.
       if (eventSource.readyState === EventSource.CLOSED) {
         settled = true;
         void finish();
+        return;
       }
+      logger.warn("[streamByEventSource] error", event);
     });
     eventSource.addEventListener("open", () => {
       logger.debug("[streamByEventSource] open");

--- a/packages/ui/src/workflows/store/handler.ts
+++ b/packages/ui/src/workflows/store/handler.ts
@@ -232,10 +232,6 @@ export function createActions(state: HandlerState, client: Client) {
         });
       };
 
-      // Resolve the cursor once per call: explicit option wins, otherwise fall
-      // back to whatever we last observed for this handler. This is what fixes
-      // the dropped-events window when a component unmounts+remounts between
-      // emitted events.
       const resolvedAfterSequence = resolveAfterSequence(
         options.afterSequence,
         handlerCursors.get(state.handler_id)
@@ -278,8 +274,6 @@ function resolveAfterSequence(
   const parsed = Number(stored);
   return Number.isFinite(parsed) ? parsed : undefined;
 }
-
-const EVENT_SOURCE_CLOSED = 2;
 
 function streamByEventSource(
   params: {
@@ -368,7 +362,7 @@ function streamByEventSource(
       // accumulated so re-subscribes to a drained handler don't hang.
       logger.warn("[streamByEventSource] error", event);
       if (settled) return;
-      if (eventSource.readyState === EVENT_SOURCE_CLOSED) {
+      if (eventSource.readyState === EventSource.CLOSED) {
         settled = true;
         void finish();
       }

--- a/packages/ui/src/workflows/store/handler.ts
+++ b/packages/ui/src/workflows/store/handler.ts
@@ -73,6 +73,28 @@ export const createState = (
   return proxy(state);
 };
 
+/**
+ * Options for `subscribeToEvents`.
+ */
+export interface SubscribeToEventsOptions {
+  /** Include internal workflow events (step state changes etc.). */
+  includeInternal?: boolean;
+  /**
+   * Sequence cursor passed to the server as `after_sequence`. Omit to let the
+   * client auto-resume from the last event it observed for this handler, or
+   * pass `"now"` to explicitly skip history. Use `-1` to replay from the
+   * beginning. Note: `SharedStreamingManager` dedupes concurrent subscribers
+   * on the same handler — only the first subscriber's cursor drives the
+   * underlying connection.
+   */
+  afterSequence?: number | "now";
+}
+
+// Module-private cursor store, keyed by handler_id. Kept off the valtio state
+// to avoid a proxy mutation per event for consumers using whole-state
+// snapshots.
+const handlerCursors = new Map<string, string>();
+
 export function createActions(state: HandlerState, client: Client) {
   const actions = {
     async sendEvent(
@@ -147,13 +169,26 @@ export function createActions(state: HandlerState, client: Client) {
         state.loading = false;
       }
     },
+    /**
+     * Subscribe to the SSE event stream for this handler.
+     *
+     * Passing a boolean as the second argument is deprecated — use
+     * `{ includeInternal }` instead. When no `afterSequence` is provided the
+     * client auto-resumes from the last event id observed for this handler
+     * (within the current session) so that tearing down and re-subscribing
+     * doesn't drop events emitted in between.
+     */
     subscribeToEvents(
       callbacks?: StreamSubscriber<WorkflowEvent>,
-      includeInternal = false
+      optionsOrIncludeInternal?: SubscribeToEventsOptions | boolean
     ): StreamOperation<WorkflowEvent> {
       if (!state.handler_id) {
         throw new Error("Handler ID is not yet initialized");
       }
+      const options: SubscribeToEventsOptions =
+        typeof optionsOrIncludeInternal === "boolean"
+          ? { includeInternal: optionsOrIncludeInternal }
+          : (optionsOrIncludeInternal ?? {});
       const streamKey = `handler:${state.handler_id}`;
 
       // Convert callback to SharedStreamingManager subscriber
@@ -197,6 +232,15 @@ export function createActions(state: HandlerState, client: Client) {
         });
       };
 
+      // Resolve the cursor once per call: explicit option wins, otherwise fall
+      // back to whatever we last observed for this handler. This is what fixes
+      // the dropped-events window when a component unmounts+remounts between
+      // emitted events.
+      const resolvedAfterSequence = resolveAfterSequence(
+        options.afterSequence,
+        handlerCursors.get(state.handler_id)
+      );
+
       // Use SharedStreamingManager to handle the streaming with deduplication
       const { promise, unsubscribe, disconnect, cancel } =
         workflowStreamingManager.subscribe(
@@ -207,7 +251,8 @@ export function createActions(state: HandlerState, client: Client) {
               {
                 client: client,
                 handlerId: state.handler_id,
-                includeInternal: includeInternal,
+                includeInternal: options.includeInternal,
+                afterSequence: resolvedAfterSequence,
                 abortSignal: signal,
               },
               subscriber,
@@ -224,11 +269,24 @@ export function createActions(state: HandlerState, client: Client) {
   return actions;
 }
 
+function resolveAfterSequence(
+  explicit: number | "now" | undefined,
+  stored: string | undefined
+): number | "now" | undefined {
+  if (explicit !== undefined) return explicit;
+  if (stored === undefined) return undefined;
+  const parsed = Number(stored);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+const EVENT_SOURCE_CLOSED = 2;
+
 function streamByEventSource(
   params: {
     client: Client;
     handlerId: string;
     includeInternal?: boolean;
+    afterSequence?: number | "now";
     abortSignal?: AbortSignal;
   },
   callbacks: StreamSubscriber<WorkflowEvent>,
@@ -245,7 +303,11 @@ function streamByEventSource(
     if (params.includeInternal) {
       urlParams.set("include_internal", "true");
     }
+    if (params.afterSequence !== undefined) {
+      urlParams.set("after_sequence", String(params.afterSequence));
+    }
     const accumulatedEvents: WorkflowEvent[] = [];
+    let settled = false;
     const eventSource = new EventSource(
       `${baseUrl}/events/${encodeURIComponent(params.handlerId)}?${urlParams.toString()}`,
       {
@@ -254,52 +316,66 @@ function streamByEventSource(
     );
     if (params.abortSignal) {
       params.abortSignal.addEventListener("abort", () => {
+        settled = true;
         eventSource.close();
       });
     }
+
+    const finish = async () => {
+      await actions.sync();
+      // Handler has drained at this point; drop any stored cursor so the next
+      // subscribe (for a fresh run that reuses the handler id, or a resubscribe
+      // to the terminal state) starts clean.
+      handlerCursors.delete(params.handlerId);
+      if (state.status === "completed") {
+        callbacks.onSuccess?.(accumulatedEvents);
+      } else if (state.status === "failed") {
+        callbacks.onError?.(new Error(state.error || "Server Error"));
+      } else if (state.status === "cancelled") {
+        callbacks.onCancel?.();
+      } else {
+        // Fall back to onSuccess for unknown terminal states so subscribers
+        // don't hang. This covers drained handlers where the server closed
+        // the stream (204) before we observed a StopEvent.
+        callbacks.onSuccess?.(accumulatedEvents);
+      }
+      resolve(accumulatedEvents);
+    };
 
     eventSource.addEventListener("message", (event) => {
       logger.debug("[streamByEventSource] message", JSON.parse(event.data));
       const workflowEvent = WorkflowEvent.fromRawEvent(
         JSON.parse(event.data) as EventEnvelopeWithMetadata
       );
+      // Record the server's sequence id so a subsequent subscribe can resume
+      // from exactly here without dropping events.
+      if (event.lastEventId) {
+        handlerCursors.set(params.handlerId, event.lastEventId);
+      }
       callbacks.onData?.(workflowEvent);
       accumulatedEvents.push(workflowEvent);
       if (isStopEvent(workflowEvent)) {
+        if (settled) return;
+        settled = true;
         eventSource.close();
-        actions.sync().then(() => {
-          if (state.status === "completed") {
-            callbacks.onSuccess?.(accumulatedEvents);
-          } else if (state.status === "failed") {
-            callbacks.onError?.(new Error(state.error || "Server Error"));
-          } else if (state.status === "cancelled") {
-            callbacks.onCancel?.();
-          } else {
-            // This should never happen
-            throw new Error(
-              `[This should never happen] Unexpected running status: ${state.status}`
-            );
-          }
-          resolve(accumulatedEvents);
-        });
+        void finish();
       }
     });
     eventSource.addEventListener("error", (event) => {
-      // Ignore error for now due to EventSource limitations.
-      // 1. Now py server close sse connection and will always trigger error event even readyState is 2 (CLOSED)
-      // 2. The error event isself is a general event without any error information
-      // TODO: swtich to more fetch + stream approach
+      // The Python server closes the SSE connection by surfacing an `error`
+      // event with readyState === CLOSED, including for the 204 "handler
+      // drained" response. Treat that as a clean close and flush whatever we
+      // accumulated so re-subscribes to a drained handler don't hang.
       logger.warn("[streamByEventSource] error", event);
-      return;
+      if (settled) return;
+      if (eventSource.readyState === EVENT_SOURCE_CLOSED) {
+        settled = true;
+        void finish();
+      }
     });
     eventSource.addEventListener("open", () => {
       logger.debug("[streamByEventSource] open");
       callbacks.onStart?.();
-    });
-    eventSource.addEventListener("close", () => {
-      logger.debug("[streamByEventSource] close");
-      callbacks.onSuccess?.(accumulatedEvents);
-      resolve(accumulatedEvents);
     });
   });
 }

--- a/packages/ui/tests/test-setup.ts
+++ b/packages/ui/tests/test-setup.ts
@@ -16,11 +16,12 @@ afterEach(() => {
 configure({ asyncUtilTimeout: 10000 });
 
 // Mock EventSource for Node.js environment (used in streaming tests)
-class MockEventSource {
+export class MockEventSource {
   url: string;
   listeners: Record<string, Set<(e: any) => void>> = {
     message: new Set(),
     error: new Set(),
+    open: new Set(),
   };
   static CLOSED = 2;
   readyState = 0;
@@ -41,6 +42,10 @@ class MockEventSource {
 
   close() {
     this.readyState = MockEventSource.CLOSED;
+  }
+
+  dispatch(type: "message" | "error" | "open", event: any) {
+    this.listeners[type]?.forEach((cb) => cb(event));
   }
 }
 

--- a/packages/ui/tests/workflows/subscribe-to-events-cursor.test.ts
+++ b/packages/ui/tests/workflows/subscribe-to-events-cursor.test.ts
@@ -29,6 +29,15 @@ function makeStartEnvelope(value: Record<string, unknown> = {}) {
   };
 }
 
+function makeStopEnvelope(result: unknown = null) {
+  return {
+    value: { result },
+    type: "StopEvent",
+    types: [],
+    qualified_name: "StopEvent",
+  };
+}
+
 // Each test uses a unique handler id so the module-level cursor map in
 // handler.ts doesn't leak state across tests.
 let nextHandlerId = 0;
@@ -64,7 +73,23 @@ describe("subscribeToEvents cursor", () => {
     await waitFor(() => {
       expect(result.current.state.status).toBe("running");
     });
-    return result;
+    const terminal = (
+      status: "completed" | "failed" | "cancelled",
+      extras: Record<string, unknown> = {}
+    ) => {
+      (workflowsClient.getHandlersByHandlerId as any).mockResolvedValue({
+        data: {
+          handler_id: id,
+          workflow_name: "wf",
+          status,
+          started_at: new Date().toISOString(),
+          error: "",
+          ...extras,
+        },
+        error: undefined,
+      });
+    };
+    return { result, terminal };
   };
 
   const nextEventSource = async () => {
@@ -77,7 +102,7 @@ describe("subscribeToEvents cursor", () => {
   };
 
   it("passes afterSequence through to the request URL", async () => {
-    const result = await mountRunningHandler();
+    const { result } = await mountRunningHandler();
 
     await act(async () => {
       result.current.subscribeToEvents({}, { afterSequence: 5 });
@@ -88,7 +113,7 @@ describe("subscribeToEvents cursor", () => {
   });
 
   it("supports the legacy boolean includeInternal arg", async () => {
-    const result = await mountRunningHandler();
+    const { result } = await mountRunningHandler();
 
     await act(async () => {
       result.current.subscribeToEvents({}, true);
@@ -100,7 +125,7 @@ describe("subscribeToEvents cursor", () => {
   });
 
   it("omits after_sequence when no cursor is set and none passed", async () => {
-    const result = await mountRunningHandler();
+    const { result } = await mountRunningHandler();
 
     await act(async () => {
       result.current.subscribeToEvents({});
@@ -111,7 +136,7 @@ describe("subscribeToEvents cursor", () => {
   });
 
   it("auto-resumes from the last observed sequence after teardown", async () => {
-    const result = await mountRunningHandler();
+    const { result } = await mountRunningHandler();
 
     let firstOp!: ReturnType<typeof result.current.subscribeToEvents>;
     await act(async () => {
@@ -139,7 +164,7 @@ describe("subscribeToEvents cursor", () => {
   });
 
   it("explicit afterSequence wins over the stored cursor", async () => {
-    const result = await mountRunningHandler();
+    const { result } = await mountRunningHandler();
 
     let firstOp!: ReturnType<typeof result.current.subscribeToEvents>;
     await act(async () => {
@@ -163,7 +188,7 @@ describe("subscribeToEvents cursor", () => {
   });
 
   it("flushes and clears the cursor when the server closes the stream (204)", async () => {
-    const result = await mountRunningHandler();
+    const { result } = await mountRunningHandler();
 
     const onSuccess = vi.fn();
     const onComplete = vi.fn();
@@ -190,5 +215,96 @@ describe("subscribeToEvents cursor", () => {
     const second = await nextEventSource();
     expect(second).not.toBe(first);
     expect(second.url).not.toContain("after_sequence");
+  });
+
+  it("fires onSuccess on StopEvent when the handler completes", async () => {
+    const { result, terminal } = await mountRunningHandler();
+    terminal("completed");
+
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    let op!: ReturnType<typeof result.current.subscribeToEvents>;
+    await act(async () => {
+      op = result.current.subscribeToEvents({ onSuccess, onError });
+    });
+    const es = await nextEventSource();
+
+    await act(async () => {
+      es.dispatch("message", makeMessage(makeStopEnvelope("ok"), "1"));
+      await op.promise;
+    });
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("fires onError when the terminal status is failed", async () => {
+    const { result, terminal } = await mountRunningHandler();
+    terminal("failed", { error: "boom" });
+
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    let op!: ReturnType<typeof result.current.subscribeToEvents>;
+    await act(async () => {
+      op = result.current.subscribeToEvents({ onSuccess, onError });
+    });
+    const es = await nextEventSource();
+
+    await act(async () => {
+      es.readyState = MockEventSource.CLOSED;
+      es.dispatch("error", {});
+      await op.promise;
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(onError.mock.calls[0][0].message).toBe("boom");
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("resolves cleanly when the terminal status is cancelled", async () => {
+    // The SharedStreamingManager composite subscriber doesn't forward
+    // onCancel today, so we can't assert the callback — just verify the
+    // cancelled branch of finish() resolves the promise without erroring.
+    const { result, terminal } = await mountRunningHandler();
+    terminal("cancelled");
+
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    let op!: ReturnType<typeof result.current.subscribeToEvents>;
+    await act(async () => {
+      op = result.current.subscribeToEvents({ onSuccess, onError });
+    });
+    const es = await nextEventSource();
+
+    await act(async () => {
+      es.readyState = MockEventSource.CLOSED;
+      es.dispatch("error", {});
+      await op.promise;
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("closes the EventSource when the last subscriber unsubscribes", async () => {
+    const { result } = await mountRunningHandler();
+
+    let op!: ReturnType<typeof result.current.subscribeToEvents>;
+    await act(async () => {
+      op = result.current.subscribeToEvents({});
+    });
+    const es = await nextEventSource();
+    expect(es.readyState).not.toBe(MockEventSource.CLOSED);
+
+    await act(async () => {
+      op.unsubscribe();
+      await Promise.resolve();
+    });
+
+    expect(es.readyState).toBe(MockEventSource.CLOSED);
   });
 });

--- a/packages/ui/tests/workflows/subscribe-to-events-cursor.test.ts
+++ b/packages/ui/tests/workflows/subscribe-to-events-cursor.test.ts
@@ -188,7 +188,8 @@ describe("subscribeToEvents cursor", () => {
   });
 
   it("flushes and clears the cursor when the server closes the stream (204)", async () => {
-    const { result } = await mountRunningHandler();
+    const { result, terminal } = await mountRunningHandler();
+    terminal("completed");
 
     const onSuccess = vi.fn();
     const onComplete = vi.fn();
@@ -288,6 +289,85 @@ describe("subscribeToEvents cursor", () => {
 
     expect(onSuccess).not.toHaveBeenCalled();
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("fires onError when the stream closes and the handler isn't terminal", async () => {
+    // Leaves the mocked handler status as "running" — if the EventSource
+    // closes cleanly but the handler hasn't drained server-side, something is
+    // off; we want an error, not a silent onSuccess.
+    const { result } = await mountRunningHandler();
+
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    let op!: ReturnType<typeof result.current.subscribeToEvents>;
+    await act(async () => {
+      op = result.current.subscribeToEvents({ onSuccess, onError });
+    });
+    const es = await nextEventSource();
+
+    await act(async () => {
+      es.readyState = MockEventSource.CLOSED;
+      es.dispatch("error", {});
+      await op.promise;
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("does not log a warning on a clean close (readyState=CLOSED)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { result, terminal } = await mountRunningHandler();
+    terminal("completed");
+
+    let op!: ReturnType<typeof result.current.subscribeToEvents>;
+    await act(async () => {
+      op = result.current.subscribeToEvents({});
+    });
+    const es = await nextEventSource();
+
+    await act(async () => {
+      es.readyState = MockEventSource.CLOSED;
+      es.dispatch("error", {});
+      await op.promise;
+    });
+
+    const streamWarnings = warnSpy.mock.calls.filter((args) =>
+      args.some(
+        (a) => typeof a === "string" && a.includes("[streamByEventSource]")
+      )
+    );
+    expect(streamWarnings).toHaveLength(0);
+
+    warnSpy.mockRestore();
+  });
+
+  it("logs a warning on a transient error (readyState=CONNECTING)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { result } = await mountRunningHandler();
+
+    await act(async () => {
+      result.current.subscribeToEvents({});
+    });
+    const es = await nextEventSource();
+
+    await act(async () => {
+      // CONNECTING == 0, the native EventSource reconnect state
+      es.readyState = 0;
+      es.dispatch("error", {});
+      await Promise.resolve();
+    });
+
+    const streamWarnings = warnSpy.mock.calls.filter((args) =>
+      args.some(
+        (a) => typeof a === "string" && a.includes("[streamByEventSource]")
+      )
+    );
+    expect(streamWarnings.length).toBeGreaterThanOrEqual(1);
+
+    warnSpy.mockRestore();
   });
 
   it("closes the EventSource when the last subscriber unsubscribes", async () => {

--- a/packages/ui/tests/workflows/subscribe-to-events-cursor.test.ts
+++ b/packages/ui/tests/workflows/subscribe-to-events-cursor.test.ts
@@ -3,6 +3,7 @@ import { act, waitFor } from "@testing-library/react";
 import { useHandler } from "../../src/workflows/hooks";
 import { renderHookWithProviderProps } from "../test-utils";
 import { workflowStreamingManager } from "../../src/lib/shared-streaming";
+import { MockEventSource } from "../test-setup";
 import * as workflowsClient from "@llamaindex/workflows-client";
 
 vi.mock("@llamaindex/workflows-client", async () => {
@@ -14,30 +15,6 @@ vi.mock("@llamaindex/workflows-client", async () => {
     postHandlersByHandlerIdCancel: vi.fn(),
   };
 });
-
-// Re-declared so we can reach into the captured EventSource instances the mock
-// from tests/test-setup.ts stores. Kept intentionally minimal.
-interface MockEventSourceInstance {
-  url: string;
-  readyState: number;
-  listeners: Record<string, Set<(e: any) => void>>;
-  close: () => void;
-}
-interface MockEventSourceCtor {
-  CLOSED: number;
-  instances: MockEventSourceInstance[];
-}
-
-const getEventSourceCtor = (): MockEventSourceCtor =>
-  (globalThis as any).EventSource as unknown as MockEventSourceCtor;
-
-function dispatch(
-  es: MockEventSourceInstance,
-  type: "message" | "error",
-  event: unknown
-) {
-  es.listeners[type]?.forEach((cb) => cb(event));
-}
 
 function makeMessage(data: unknown, lastEventId: string) {
   return { data: JSON.stringify(data), lastEventId };
@@ -52,17 +29,27 @@ function makeStartEnvelope(value: Record<string, unknown> = {}) {
   };
 }
 
+// Each test uses a unique handler id so the module-level cursor map in
+// handler.ts doesn't leak state across tests.
+let nextHandlerId = 0;
+const freshHandlerId = () => `h-cursor-${++nextHandlerId}`;
+
 describe("subscribeToEvents cursor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Fresh EventSource instance array per test.
-    getEventSourceCtor().instances.length = 0;
-    // The streaming manager is a module-level singleton; close any leftovers.
+    MockEventSource.instances.length = 0;
     workflowStreamingManager.closeAllStreams();
+  });
 
+  afterEach(() => {
+    workflowStreamingManager.closeAllStreams();
+  });
+
+  const mountRunningHandler = async () => {
+    const id = freshHandlerId();
     (workflowsClient.getHandlersByHandlerId as any).mockResolvedValue({
       data: {
-        handler_id: "h-cursor",
+        handler_id: id,
         workflow_name: "wf",
         status: "running",
         started_at: new Date().toISOString(),
@@ -70,177 +57,113 @@ describe("subscribeToEvents cursor", () => {
       },
       error: undefined,
     });
-  });
-
-  afterEach(() => {
-    workflowStreamingManager.closeAllStreams();
-  });
-
-  it("passes afterSequence through to the request URL", async () => {
     const { result } = renderHookWithProviderProps<{ id: string | null }, any>(
       ({ id }: { id: string | null }) => useHandler(id),
-      {
-        initialProps: { id: "h-cursor" },
-      }
+      { initialProps: { id } }
     );
-
     await waitFor(() => {
       expect(result.current.state.status).toBe("running");
     });
+    return result;
+  };
+
+  const nextEventSource = async () => {
+    // Let the streaming manager's executor run and construct the EventSource.
+    await Promise.resolve();
+    await Promise.resolve();
+    const es = MockEventSource.instances.at(-1);
+    if (!es) throw new Error("expected an EventSource to have been created");
+    return es;
+  };
+
+  it("passes afterSequence through to the request URL", async () => {
+    const result = await mountRunningHandler();
 
     await act(async () => {
       result.current.subscribeToEvents({}, { afterSequence: 5 });
-      // let the executor kick the EventSource ctor
-      await Promise.resolve();
-      await Promise.resolve();
     });
 
-    const instances = getEventSourceCtor().instances;
-    expect(instances).toHaveLength(1);
-    expect(instances[0].url).toContain("after_sequence=5");
+    const es = await nextEventSource();
+    expect(es.url).toContain("after_sequence=5");
   });
 
   it("supports the legacy boolean includeInternal arg", async () => {
-    const { result } = renderHookWithProviderProps<{ id: string | null }, any>(
-      ({ id }: { id: string | null }) => useHandler(id),
-      {
-        initialProps: { id: "h-cursor" },
-      }
-    );
-
-    await waitFor(() => {
-      expect(result.current.state.status).toBe("running");
-    });
+    const result = await mountRunningHandler();
 
     await act(async () => {
       result.current.subscribeToEvents({}, true);
-      await Promise.resolve();
-      await Promise.resolve();
     });
 
-    const instances = getEventSourceCtor().instances;
-    expect(instances).toHaveLength(1);
-    expect(instances[0].url).toContain("include_internal=true");
-    expect(instances[0].url).not.toContain("after_sequence");
+    const es = await nextEventSource();
+    expect(es.url).toContain("include_internal=true");
+    expect(es.url).not.toContain("after_sequence");
   });
 
   it("omits after_sequence when no cursor is set and none passed", async () => {
-    const { result } = renderHookWithProviderProps<{ id: string | null }, any>(
-      ({ id }: { id: string | null }) => useHandler(id),
-      {
-        initialProps: { id: "h-cursor" },
-      }
-    );
-
-    await waitFor(() => {
-      expect(result.current.state.status).toBe("running");
-    });
+    const result = await mountRunningHandler();
 
     await act(async () => {
       result.current.subscribeToEvents({});
-      await Promise.resolve();
-      await Promise.resolve();
     });
 
-    const instances = getEventSourceCtor().instances;
-    expect(instances).toHaveLength(1);
-    expect(instances[0].url).not.toContain("after_sequence");
+    const es = await nextEventSource();
+    expect(es.url).not.toContain("after_sequence");
   });
 
   it("auto-resumes from the last observed sequence after teardown", async () => {
-    const { result } = renderHookWithProviderProps<{ id: string | null }, any>(
-      ({ id }: { id: string | null }) => useHandler(id),
-      {
-        initialProps: { id: "h-cursor" },
-      }
-    );
+    const result = await mountRunningHandler();
 
-    await waitFor(() => {
-      expect(result.current.state.status).toBe("running");
-    });
-
-    // First subscription — receive ids 1,2,3 then tear down.
     let firstOp!: ReturnType<typeof result.current.subscribeToEvents>;
     await act(async () => {
       firstOp = result.current.subscribeToEvents({});
-      await Promise.resolve();
-      await Promise.resolve();
     });
 
-    const instances = getEventSourceCtor().instances;
-    expect(instances).toHaveLength(1);
-    expect(instances[0].url).not.toContain("after_sequence");
+    const first = await nextEventSource();
+    expect(first.url).not.toContain("after_sequence");
 
     await act(async () => {
       for (const seq of ["1", "2", "3"]) {
-        dispatch(
-          instances[0],
-          "message",
-          makeMessage(makeStartEnvelope(), seq)
-        );
+        first.dispatch("message", makeMessage(makeStartEnvelope(), seq));
       }
       firstOp.unsubscribe();
       await Promise.resolve();
     });
 
-    // Second subscription — should include after_sequence=3.
     await act(async () => {
       result.current.subscribeToEvents({});
-      await Promise.resolve();
-      await Promise.resolve();
     });
 
-    expect(instances).toHaveLength(2);
-    expect(instances[1].url).toContain("after_sequence=3");
+    const second = await nextEventSource();
+    expect(second).not.toBe(first);
+    expect(second.url).toContain("after_sequence=3");
   });
 
   it("explicit afterSequence wins over the stored cursor", async () => {
-    const { result } = renderHookWithProviderProps<{ id: string | null }, any>(
-      ({ id }: { id: string | null }) => useHandler(id),
-      {
-        initialProps: { id: "h-cursor" },
-      }
-    );
-
-    await waitFor(() => {
-      expect(result.current.state.status).toBe("running");
-    });
+    const result = await mountRunningHandler();
 
     let firstOp!: ReturnType<typeof result.current.subscribeToEvents>;
     await act(async () => {
       firstOp = result.current.subscribeToEvents({});
-      await Promise.resolve();
-      await Promise.resolve();
     });
+    const first = await nextEventSource();
 
-    const instances = getEventSourceCtor().instances;
     await act(async () => {
-      dispatch(instances[0], "message", makeMessage(makeStartEnvelope(), "7"));
+      first.dispatch("message", makeMessage(makeStartEnvelope(), "7"));
       firstOp.unsubscribe();
       await Promise.resolve();
     });
 
     await act(async () => {
       result.current.subscribeToEvents({}, { afterSequence: "now" });
-      await Promise.resolve();
-      await Promise.resolve();
     });
+    const second = await nextEventSource();
 
-    expect(instances[1].url).toContain("after_sequence=now");
-    expect(instances[1].url).not.toContain("after_sequence=7");
+    expect(second.url).toContain("after_sequence=now");
+    expect(second.url).not.toContain("after_sequence=7");
   });
 
   it("flushes and clears the cursor when the server closes the stream (204)", async () => {
-    const { result } = renderHookWithProviderProps<{ id: string | null }, any>(
-      ({ id }: { id: string | null }) => useHandler(id),
-      {
-        initialProps: { id: "h-cursor" },
-      }
-    );
-
-    await waitFor(() => {
-      expect(result.current.state.status).toBe("running");
-    });
+    const result = await mountRunningHandler();
 
     const onSuccess = vi.fn();
     const onComplete = vi.fn();
@@ -248,31 +171,24 @@ describe("subscribeToEvents cursor", () => {
     let op!: ReturnType<typeof result.current.subscribeToEvents>;
     await act(async () => {
       op = result.current.subscribeToEvents({ onSuccess, onComplete });
-      await Promise.resolve();
-      await Promise.resolve();
     });
+    const first = await nextEventSource();
 
-    const instances = getEventSourceCtor().instances;
     await act(async () => {
-      dispatch(instances[0], "message", makeMessage(makeStartEnvelope(), "9"));
-      // Simulate py server closing the SSE stream: readyState CLOSED +
-      // error event with no data.
-      instances[0].readyState = getEventSourceCtor().CLOSED;
-      dispatch(instances[0], "error", {});
+      first.dispatch("message", makeMessage(makeStartEnvelope(), "9"));
+      first.readyState = MockEventSource.CLOSED;
+      first.dispatch("error", {});
       await op.promise;
     });
 
     expect(onSuccess).toHaveBeenCalledTimes(1);
     expect(onComplete).toHaveBeenCalledTimes(1);
 
-    // A fresh subscription should not carry the cleared cursor forward.
     await act(async () => {
       result.current.subscribeToEvents({});
-      await Promise.resolve();
-      await Promise.resolve();
     });
-
-    expect(instances).toHaveLength(2);
-    expect(instances[1].url).not.toContain("after_sequence");
+    const second = await nextEventSource();
+    expect(second).not.toBe(first);
+    expect(second.url).not.toContain("after_sequence");
   });
 });

--- a/packages/ui/tests/workflows/subscribe-to-events-cursor.test.ts
+++ b/packages/ui/tests/workflows/subscribe-to-events-cursor.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, waitFor } from "@testing-library/react";
+import { useHandler } from "../../src/workflows/hooks";
+import { renderHookWithProviderProps } from "../test-utils";
+import { workflowStreamingManager } from "../../src/lib/shared-streaming";
+import * as workflowsClient from "@llamaindex/workflows-client";
+
+vi.mock("@llamaindex/workflows-client", async () => {
+  const actual = await vi.importActual<any>("@llamaindex/workflows-client");
+  return {
+    ...actual,
+    getHandlersByHandlerId: vi.fn(),
+    postEventsByHandlerId: vi.fn(),
+    postHandlersByHandlerIdCancel: vi.fn(),
+  };
+});
+
+// Re-declared so we can reach into the captured EventSource instances the mock
+// from tests/test-setup.ts stores. Kept intentionally minimal.
+interface MockEventSourceInstance {
+  url: string;
+  readyState: number;
+  listeners: Record<string, Set<(e: any) => void>>;
+  close: () => void;
+}
+interface MockEventSourceCtor {
+  CLOSED: number;
+  instances: MockEventSourceInstance[];
+}
+
+const getEventSourceCtor = (): MockEventSourceCtor =>
+  (globalThis as any).EventSource as unknown as MockEventSourceCtor;
+
+function dispatch(
+  es: MockEventSourceInstance,
+  type: "message" | "error",
+  event: unknown
+) {
+  es.listeners[type]?.forEach((cb) => cb(event));
+}
+
+function makeMessage(data: unknown, lastEventId: string) {
+  return { data: JSON.stringify(data), lastEventId };
+}
+
+function makeStartEnvelope(value: Record<string, unknown> = {}) {
+  return {
+    value,
+    type: "StartEvent",
+    types: [],
+    qualified_name: "StartEvent",
+  };
+}
+
+describe("subscribeToEvents cursor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Fresh EventSource instance array per test.
+    getEventSourceCtor().instances.length = 0;
+    // The streaming manager is a module-level singleton; close any leftovers.
+    workflowStreamingManager.closeAllStreams();
+
+    (workflowsClient.getHandlersByHandlerId as any).mockResolvedValue({
+      data: {
+        handler_id: "h-cursor",
+        workflow_name: "wf",
+        status: "running",
+        started_at: new Date().toISOString(),
+        error: "",
+      },
+      error: undefined,
+    });
+  });
+
+  afterEach(() => {
+    workflowStreamingManager.closeAllStreams();
+  });
+
+  it("passes afterSequence through to the request URL", async () => {
+    const { result } = renderHookWithProviderProps<{ id: string | null }, any>(
+      ({ id }: { id: string | null }) => useHandler(id),
+      {
+        initialProps: { id: "h-cursor" },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("running");
+    });
+
+    await act(async () => {
+      result.current.subscribeToEvents({}, { afterSequence: 5 });
+      // let the executor kick the EventSource ctor
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const instances = getEventSourceCtor().instances;
+    expect(instances).toHaveLength(1);
+    expect(instances[0].url).toContain("after_sequence=5");
+  });
+
+  it("supports the legacy boolean includeInternal arg", async () => {
+    const { result } = renderHookWithProviderProps<{ id: string | null }, any>(
+      ({ id }: { id: string | null }) => useHandler(id),
+      {
+        initialProps: { id: "h-cursor" },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("running");
+    });
+
+    await act(async () => {
+      result.current.subscribeToEvents({}, true);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const instances = getEventSourceCtor().instances;
+    expect(instances).toHaveLength(1);
+    expect(instances[0].url).toContain("include_internal=true");
+    expect(instances[0].url).not.toContain("after_sequence");
+  });
+
+  it("omits after_sequence when no cursor is set and none passed", async () => {
+    const { result } = renderHookWithProviderProps<{ id: string | null }, any>(
+      ({ id }: { id: string | null }) => useHandler(id),
+      {
+        initialProps: { id: "h-cursor" },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("running");
+    });
+
+    await act(async () => {
+      result.current.subscribeToEvents({});
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const instances = getEventSourceCtor().instances;
+    expect(instances).toHaveLength(1);
+    expect(instances[0].url).not.toContain("after_sequence");
+  });
+
+  it("auto-resumes from the last observed sequence after teardown", async () => {
+    const { result } = renderHookWithProviderProps<{ id: string | null }, any>(
+      ({ id }: { id: string | null }) => useHandler(id),
+      {
+        initialProps: { id: "h-cursor" },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("running");
+    });
+
+    // First subscription — receive ids 1,2,3 then tear down.
+    let firstOp!: ReturnType<typeof result.current.subscribeToEvents>;
+    await act(async () => {
+      firstOp = result.current.subscribeToEvents({});
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const instances = getEventSourceCtor().instances;
+    expect(instances).toHaveLength(1);
+    expect(instances[0].url).not.toContain("after_sequence");
+
+    await act(async () => {
+      for (const seq of ["1", "2", "3"]) {
+        dispatch(
+          instances[0],
+          "message",
+          makeMessage(makeStartEnvelope(), seq)
+        );
+      }
+      firstOp.unsubscribe();
+      await Promise.resolve();
+    });
+
+    // Second subscription — should include after_sequence=3.
+    await act(async () => {
+      result.current.subscribeToEvents({});
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(instances).toHaveLength(2);
+    expect(instances[1].url).toContain("after_sequence=3");
+  });
+
+  it("explicit afterSequence wins over the stored cursor", async () => {
+    const { result } = renderHookWithProviderProps<{ id: string | null }, any>(
+      ({ id }: { id: string | null }) => useHandler(id),
+      {
+        initialProps: { id: "h-cursor" },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("running");
+    });
+
+    let firstOp!: ReturnType<typeof result.current.subscribeToEvents>;
+    await act(async () => {
+      firstOp = result.current.subscribeToEvents({});
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const instances = getEventSourceCtor().instances;
+    await act(async () => {
+      dispatch(instances[0], "message", makeMessage(makeStartEnvelope(), "7"));
+      firstOp.unsubscribe();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      result.current.subscribeToEvents({}, { afterSequence: "now" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(instances[1].url).toContain("after_sequence=now");
+    expect(instances[1].url).not.toContain("after_sequence=7");
+  });
+
+  it("flushes and clears the cursor when the server closes the stream (204)", async () => {
+    const { result } = renderHookWithProviderProps<{ id: string | null }, any>(
+      ({ id }: { id: string | null }) => useHandler(id),
+      {
+        initialProps: { id: "h-cursor" },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("running");
+    });
+
+    const onSuccess = vi.fn();
+    const onComplete = vi.fn();
+
+    let op!: ReturnType<typeof result.current.subscribeToEvents>;
+    await act(async () => {
+      op = result.current.subscribeToEvents({ onSuccess, onComplete });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const instances = getEventSourceCtor().instances;
+    await act(async () => {
+      dispatch(instances[0], "message", makeMessage(makeStartEnvelope(), "9"));
+      // Simulate py server closing the SSE stream: readyState CLOSED +
+      // error event with no data.
+      instances[0].readyState = getEventSourceCtor().CLOSED;
+      dispatch(instances[0], "error", {});
+      await op.promise;
+    });
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+
+    // A fresh subscription should not carry the cleared cursor forward.
+    await act(async () => {
+      result.current.subscribeToEvents({});
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(instances).toHaveLength(2);
+    expect(instances[1].url).not.toContain("after_sequence");
+  });
+});

--- a/packages/workflow-debugger/src/components/run-details-panel.tsx
+++ b/packages/workflow-debugger/src/components/run-details-panel.tsx
@@ -94,7 +94,7 @@ export function RunDetailsPanel({
             setFinalResultError(error.message);
           },
         },
-        true,
+        { includeInternal: true },
       );
       return () => {
         disconnect();


### PR DESCRIPTION
## Summary

- Tracks the last-seen SSE sequence id per handler; the next subscribe auto-resumes from it so unmount/remount no longer drops events.
- Adds `{ afterSequence: number | "now" }` to `subscribeToEvents` for explicit cursor control. Legacy `(callbacks, boolean)` form still works.
- Flushes accumulated events and clears the cursor when the server closes the stream (204 drained), so drained handlers don't hang subscribers.

## Why

`SharedStreamingManager` correctly tears down the underlying SSE connection when the last subscriber leaves. Re-subscribing opened a new stream at `after_sequence="now"`, silently losing any events the server emitted in between — the symptom fixed server-side by run-llama/llama-agents#560. The server already exposes `after_sequence`; fixing it on the client is the right layer.