### PR TITLE
fix(ui): restrict code language options to Python and JavaScript

### DIFF
--- a/.changeset/hot-bugs-sparkle.md
+++ b/.changeset/hot-bugs-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/ui": patch
+---
+
+Limit displayed code language options to Python and JavaScript for consistency.

--- a/packages/ui/src/lib/supported-code-languages.ts
+++ b/packages/ui/src/lib/supported-code-languages.ts
@@ -1,0 +1,22 @@
+import type { Option } from "../../base/multiple-selector";
+
+export const SUPPORTED_CODE_LANGUAGE_VALUES = ["python", "javascript"] as const;
+
+export type SupportedCodeLanguage =
+  (typeof SUPPORTED_CODE_LANGUAGE_VALUES)[number];
+
+const supportedCodeLanguageSet = new Set<string>(
+  SUPPORTED_CODE_LANGUAGE_VALUES
+);
+
+export function isSupportedCodeLanguage(
+  language: string
+): language is SupportedCodeLanguage {
+  return supportedCodeLanguageSet.has(language);
+}
+
+export function filterSupportedCodeLanguageOptions<
+  T extends Pick<Option, "value">,
+>(options: readonly T[]): T[] {
+  return options.filter((option) => isSupportedCodeLanguage(option.value));
+}

--- a/packages/ui/stories/base/multiple-selector.stories.tsx
+++ b/packages/ui/stories/base/multiple-selector.stories.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { MultipleSelector, type Option } from "../../base/multiple-selector";
 import { ThemeComparison } from "./theme-comparison";
+import { filterSupportedCodeLanguageOptions } from "../../src/lib/supported-code-languages";
 
 const frameworkOptions: Option[] = [
   { value: "react", label: "React" },
@@ -14,7 +15,7 @@ const frameworkOptions: Option[] = [
   { value: "astro", label: "Astro" },
 ];
 
-const languageOptions: Option[] = [
+const allLanguageOptions: Option[] = [
   { value: "typescript", label: "TypeScript", group: "Typed" },
   { value: "javascript", label: "JavaScript", group: "Dynamic" },
   { value: "python", label: "Python", group: "Dynamic" },
@@ -22,6 +23,8 @@ const languageOptions: Option[] = [
   { value: "go", label: "Go", group: "Typed" },
   { value: "ruby", label: "Ruby", group: "Dynamic" },
 ];
+
+const languageOptions = filterSupportedCodeLanguageOptions(allLanguageOptions);
 
 const meta: Meta<typeof MultipleSelector> = {
   title: "Base/MultipleSelector",

--- a/packages/ui/tests/lib/supported-code-languages.test.ts
+++ b/packages/ui/tests/lib/supported-code-languages.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterSupportedCodeLanguageOptions,
+  isSupportedCodeLanguage,
+  SUPPORTED_CODE_LANGUAGE_VALUES,
+} from "../../src/lib/supported-code-languages";
+
+describe("supported code languages", () => {
+  it("allows only Python and JavaScript", () => {
+    expect(SUPPORTED_CODE_LANGUAGE_VALUES).toEqual(["python", "javascript"]);
+  });
+
+  it("identifies supported code languages", () => {
+    expect(isSupportedCodeLanguage("python")).toBe(true);
+    expect(isSupportedCodeLanguage("javascript")).toBe(true);
+    expect(isSupportedCodeLanguage("typescript")).toBe(false);
+    expect(isSupportedCodeLanguage("go")).toBe(false);
+  });
+
+  it("filters option lists down to supported languages without reordering", () => {
+    const options = [
+      { value: "typescript", label: "TypeScript" },
+      { value: "javascript", label: "JavaScript" },
+      { value: "php", label: "PHP" },
+      { value: "python", label: "Python" },
+      { value: "csharp", label: "C#" },
+    ];
+
+    expect(filterSupportedCodeLanguageOptions(options)).toEqual([
+      { value: "javascript", label: "JavaScript" },
+      { value: "python", label: "Python" },
+    ]);
+  });
+});


### PR DESCRIPTION
### Motivation
- Keep language options consistent in the UI by showing only Python and JavaScript in the language selector stories.
- Reduce confusion from showing many SDK/language options in demos while preserving existing option ordering and story behavior.

### Description
- Add a small allowlist utility `packages/ui/src/lib/supported-code-languages.ts` that exports `SUPPORTED_CODE_LANGUAGE_VALUES`, `isSupportedCodeLanguage`, and `filterSupportedCodeLanguageOptions` to centralize supported languages.
- Apply the allowlist in the language selector story by replacing the previous list with `allLanguageOptions` and using `filterSupportedCodeLanguageOptions(allLanguageOptions)` in `packages/ui/stories/base/multiple-selector.stories.tsx` so only `python` and `javascript` are shown.
- Add unit tests at `packages/ui/tests/lib/supported-code-languages.test.ts` covering the allowlist, `isSupportedCodeLanguage`, and the filtering behavior.
- Add a patch changeset `.changeset/hot-bugs-sparkle.md` to document the UI change for `@llamaindex/ui`.

### Testing
- Ran the unit test: `pnpm --filter @llamaindex/ui exec vitest run -c vitest.config.ts tests/lib/supported-code-languages.test.ts --project unit`, and the tests passed.
- Ran typecheck and build: `pnpm --filter @llamaindex/ui run typecheck` and `pnpm --filter @llamaindex/ui run build`, and both completed successfully.
- Ran formatting and lint checks: `pnpm --filter @llamaindex/ui run lint:fix`, `pnpm --filter @llamaindex/ui run format`, `pnpm --filter @llamaindex/ui run lint`, and `pnpm --filter @llamaindex/ui run format-check`, and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dd0a1a41c832b84e62b8a0a6c44a0)