### PR TITLE
fix(ui): load pdf.js worker from app origin instead of unpkg

### DIFF
--- a/.changeset/pdfjs-worker-self-hosted.md
+++ b/.changeset/pdfjs-worker-self-hosted.md
@@ -1,0 +1,24 @@
+---
+"@llamaindex/ui": minor
+---
+
+Load pdf.js runtime assets from the app's own origin instead of unpkg
+
+The PDF viewer configured `pdfjs.GlobalWorkerOptions.workerSrc` to
+`//unpkg.com/pdfjs-dist@<version>/build/pdf.worker.min.mjs`, and pointed
+`cMapUrl`/`wasmUrl` at the same CDN. The worker executes with the host page's
+privileges, so a hijacked or compromised CDN response had full access to the
+application origin — on every page that previews a document.
+
+The worker is now resolved from the `pdfjs-dist` package installed alongside
+this library, so bundlers emit it as a same-origin asset. Applications can drop
+`https://unpkg.com` from their CSP `script-src`/`worker-src`.
+
+`configurePdfjs()` is exported from `@llamaindex/ui/file-preview` to point the
+viewer at self-hosted assets explicitly.
+
+Behaviour change: `cMapUrl` and `wasmUrl` are no longer set by default, because
+they are directories that bundlers cannot resolve automatically. PDFs using
+CID-keyed fonts (typically CJK) and JPEG 2000 images need those assets copied
+out of `pdfjs-dist` into your static files and registered — see the "PDF viewer
+assets" section of the package README.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -76,6 +76,49 @@ export function App() {
 }
 ```
 
+### PDF viewer assets
+
+`PdfPreview`, `FilePreview` and `DocumentPreview` render PDFs with
+[react-pdf](https://github.com/wojtekmaj/react-pdf), which needs a pdf.js
+worker at runtime. The library resolves it from the `pdfjs-dist` package
+installed alongside it, so your bundler emits it as a **same-origin** asset —
+nothing is loaded from a public CDN. The worker runs with your page's
+privileges, so serve it from an origin you control and keep your CSP
+`script-src`/`worker-src` limited to `'self'`.
+
+Two optional asset sets are **not** enabled by default, because they are
+directories that bundlers cannot resolve automatically:
+
+- `cmaps/` — required to render PDFs that use CID-keyed fonts (typically CJK
+  documents). Without it those glyphs come out blank.
+- `wasm/` — required to decode JPEG 2000 (JPX) images.
+
+To enable them, copy the directories out of `pdfjs-dist` into your static
+assets at build time and point the library at them once during start-up:
+
+```tsx
+import { configurePdfjs } from "@llamaindex/ui/file-preview";
+
+configurePdfjs({
+  cMapUrl: "/pdfjs/cmaps/",
+  wasmUrl: "/pdfjs/wasm/",
+});
+```
+
+```jsonc
+// package.json — copy the assets as part of your build
+"scripts": {
+  "prebuild": "cp -R node_modules/pdfjs-dist/cmaps node_modules/pdfjs-dist/wasm public/pdfjs/"
+}
+```
+
+`configurePdfjs` also accepts `workerSrc`. Pass it if your bundler does not
+rewrite `new URL("pdfjs-dist/build/pdf.worker.min.mjs", import.meta.url)`
+inside dependencies; with Vite, for example,
+`import workerSrc from "pdfjs-dist/build/pdf.worker.min.mjs?url"` gives you a
+URL to hand over. When the worker cannot be loaded at all, pdf.js falls back to
+rendering on the main thread: slower, but still same-origin.
+
 ## Contributing
 
 Please read the contribution guide: [CONTRIBUTING.md](https://github.com/run-llama/llama-ui/blob/main/CONTRIBUTING.md)

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -505,6 +505,7 @@
     "mammoth": "^1.9.0",
     "motion": "^12.12.1",
     "lucide-react": "^0.514.0",
+    "pdfjs-dist": "5.4.296",
     "pptx-svg": "^0.5.4",
     "react-day-picker": "^8.10.1",
     "recharts": "^2.15.3",

--- a/packages/ui/src/file-preview/index.ts
+++ b/packages/ui/src/file-preview/index.ts
@@ -2,6 +2,8 @@ export { FilePreview } from "./file-preview";
 export { PdfPreview } from "./pdf-preview";
 export { PdfNavigator } from "./pdf-navigator";
 export { useFileData } from "./use-file-data";
+export { configurePdfjs } from "./pdfjs-config";
+export type { PdfjsAssetConfig } from "./pdfjs-config";
 export type { FilePreviewProps } from "./file-preview";
 export type { BoundingBox, FileData, PageData, Highlight } from "./types";
 export type { FitMode } from "./pdf-preview-utils";

--- a/packages/ui/src/file-preview/pdf-preview-impl.tsx
+++ b/packages/ui/src/file-preview/pdf-preview-impl.tsx
@@ -6,6 +6,7 @@ import { logger } from "@shared/logger";
 import { Button } from "@/base/button";
 import { FileToolbar } from "../document-preview/file-tool-bar";
 import { BoundingBoxOverlay } from "./bounding-box-overlay";
+import { getPdfDocumentOptions, getPdfjsWorkerSrc } from "./pdfjs-config";
 import type { BoundingBox, Highlight } from "./types";
 import {
   calculateHighlightScrollPosition,
@@ -18,10 +19,14 @@ import {
   type FitMode,
 } from "./pdf-preview-utils";
 
-// Configure worker path for PDF.js
-if (typeof window !== "undefined") {
-  pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
+// Point PDF.js at the worker resolved from the pdfjs-dist package bundled with
+// the application (or at whatever `configurePdfjs` was given). Never a public
+// CDN: the worker executes with the host page's privileges.
+function applyPdfjsWorkerSrc() {
+  if (typeof window === "undefined") return;
+  pdfjs.GlobalWorkerOptions.workerSrc = getPdfjsWorkerSrc() ?? "";
 }
+applyPdfjsWorkerSrc();
 
 // Side-effect CSS imports – ignore TypeScript complaints. Also inconsistent checking between projects. Whatever
 // eslint-disable-next-line
@@ -63,11 +68,6 @@ type PageBaseDims = {
   [key: number]: { width: number; height: number };
 };
 
-const pdfOptions = {
-  cMapUrl: `https://unpkg.com/pdfjs-dist@${pdfjs.version}/cmaps/`,
-  wasmUrl: `https://unpkg.com/pdfjs-dist@${pdfjs.version}/wasm/`,
-};
-
 // Cache passwords for encrypted PDFs so remounts don't re-prompt
 const pdfPasswordCache = new Map<string, string>();
 
@@ -93,6 +93,11 @@ export const PdfPreviewImpl = ({
   maxDevicePixelRatio = 1.5,
   renderTextLayer = true,
 }: PdfPreviewImplProps) => {
+  // Re-apply in case `configurePdfjs` ran after this (lazily loaded) module
+  // was first evaluated. Idempotent global assignment.
+  applyPdfjsWorkerSrc();
+  const pdfOptions = getPdfDocumentOptions();
+
   const [numPages, setNumPages] = useState<number>();
   const [currentPage, setCurrentPage] = useState<number>(pageRange?.[0] ?? 1);
   const isScaleControlled =

--- a/packages/ui/src/file-preview/pdf-preview-impl.tsx
+++ b/packages/ui/src/file-preview/pdf-preview-impl.tsx
@@ -623,6 +623,10 @@ export const PdfPreviewImpl = ({
       passwordPromptTimeout.current = null;
     }
     setLoadError(null);
+    // Drop the outgoing document's page count before its replacement arrives.
+    // `numPages` gates the page list below; leaving it set would keep mounting
+    // <Page>s against a document react-pdf has already torn down.
+    setNumPages(undefined);
     setVisiblePages(new Set([pageRange?.[0] ?? 1]));
     setPageHeights({});
     isInitialScaleSet.current = false; // Reset so new document gets auto-scaled
@@ -654,6 +658,7 @@ export const PdfPreviewImpl = ({
     fetchFile();
     return () => {
       setFile(null);
+      setNumPages(undefined);
     };
   }, [url, fileName, pageRange]);
 
@@ -824,7 +829,10 @@ export const PdfPreviewImpl = ({
           loading={null}
           options={pdfOptions}
         >
-          {numPages && numPages > 0 && (
+          {/* `file` is part of the guard on purpose: when it is cleared,
+              react-pdf destroys the document's worker transport, and any
+              <Page> still mounting in that commit calls getPage() on it. */}
+          {file && numPages && numPages > 0 && (
             <VirtualizedPageList
               rangeStart={rangeStart}
               rangeEnd={rangeEnd}

--- a/packages/ui/src/file-preview/pdf-preview-impl.tsx
+++ b/packages/ui/src/file-preview/pdf-preview-impl.tsx
@@ -821,7 +821,16 @@ export const PdfPreviewImpl = ({
         ref={containerRef}
         className="overflow-auto h-full bg-muted flex-1 min-h-0"
       >
+        {/* Keyed by url so each document gets a fresh <Document> instance.
+            react-pdf's loader schedules `loadingTask.destroy()` on cleanup but
+            does not cancel that task's pending RESOLVE dispatch, so a
+            superseded document can still land in context and then be
+            destroyed — any <Page> mounting against it throws
+            "Cannot read properties of null (reading 'sendWithPromise')".
+            Remounting means the stale resolve dispatches into an unmounted
+            reducer instead, where it is a no-op. */}
         <Document
+          key={url}
           file={file}
           onLoadSuccess={onDocumentLoadSuccess}
           onLoadError={onDocumentLoadError}

--- a/packages/ui/src/file-preview/pdfjs-config.ts
+++ b/packages/ui/src/file-preview/pdfjs-config.ts
@@ -1,0 +1,100 @@
+"use client";
+
+/**
+ * Where the PDF viewer loads pdf.js runtime assets from.
+ *
+ * These are deliberately *not* defaulted to a public CDN. The worker in
+ * particular is a script that executes with the same privileges as the host
+ * page, so a compromised or hijacked CDN response would have full access to
+ * the application origin. Everything here should be served from an origin the
+ * application controls.
+ */
+export interface PdfjsAssetConfig {
+  /**
+   * URL of the pdf.js worker script (`pdfjs-dist/build/pdf.worker.min.mjs`).
+   * Must match the pdf.js version `react-pdf` was built against, otherwise
+   * pdf.js refuses to use it.
+   */
+  workerSrc?: string;
+  /**
+   * Directory URL (with trailing slash) holding the pdf.js CMap files, i.e. a
+   * copy of `pdfjs-dist/cmaps/`. Needed to render PDFs that use CID-keyed
+   * fonts (most commonly CJK documents). Unset by default.
+   */
+  cMapUrl?: string;
+  /**
+   * Directory URL (with trailing slash) holding the pdf.js WebAssembly
+   * modules, i.e. a copy of `pdfjs-dist/wasm/`. Needed to decode JPEG 2000
+   * (JPX) images. Unset by default.
+   */
+  wasmUrl?: string;
+}
+
+/**
+ * Resolve the worker from the `pdfjs-dist` package installed alongside this
+ * library so the application's bundler emits it as a same-origin asset.
+ *
+ * The specifier is a static string literal because that is what bundlers
+ * pattern-match on — do not build it dynamically. When the environment cannot
+ * resolve it (notably the CJS build, where `import.meta` is unavailable) this
+ * returns `undefined` and pdf.js falls back to its in-process "fake worker":
+ * slower, but still same-origin. Callers that need the real worker in such an
+ * environment should pass `workerSrc` to {@link configurePdfjs}.
+ */
+function resolveBundledWorkerSrc(): string | undefined {
+  try {
+    return new URL(
+      "pdfjs-dist/build/pdf.worker.min.mjs",
+      import.meta.url
+    ).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+let config: PdfjsAssetConfig = { workerSrc: resolveBundledWorkerSrc() };
+
+// react-pdf warns when <Document options> changes identity between renders, so
+// the object handed to it is rebuilt only when the configuration changes.
+let documentOptions: { cMapUrl?: string; wasmUrl?: string } = {};
+
+/**
+ * Point the PDF viewer at self-hosted pdf.js assets. Call once during
+ * application start-up, before any PDF is rendered.
+ *
+ * Copy the assets out of `pdfjs-dist` at build time (they ship with the
+ * package) and serve them yourself:
+ *
+ * ```ts
+ * import { configurePdfjs } from "@llamaindex/ui/file-preview";
+ *
+ * configurePdfjs({
+ *   workerSrc: "/pdfjs/pdf.worker.min.mjs",
+ *   cMapUrl: "/pdfjs/cmaps/",
+ *   wasmUrl: "/pdfjs/wasm/",
+ * });
+ * ```
+ *
+ * Only the keys you pass are changed; omit `workerSrc` to keep the
+ * bundler-resolved default.
+ */
+export function configurePdfjs(next: PdfjsAssetConfig): void {
+  config = { ...config, ...next };
+  documentOptions = { cMapUrl: config.cMapUrl, wasmUrl: config.wasmUrl };
+}
+
+/** @internal */
+export function getPdfjsWorkerSrc(): string | undefined {
+  return config.workerSrc;
+}
+
+/**
+ * Stable-identity options object for react-pdf's `<Document options>`.
+ * @internal
+ */
+export function getPdfDocumentOptions(): {
+  cMapUrl?: string;
+  wasmUrl?: string;
+} {
+  return documentOptions;
+}

--- a/packages/ui/tests/file-preview/pdf-preview-document-swap.test.tsx
+++ b/packages/ui/tests/file-preview/pdf-preview-document-swap.test.tsx
@@ -17,6 +17,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 let currentDocumentFile: File | null = null;
 const pageMounts = vi.fn();
+const documentMounts = vi.fn();
 
 vi.mock("react-pdf", () => ({
   pdfjs: { GlobalWorkerOptions: { workerSrc: "" }, version: "0.0.0-test" },
@@ -31,6 +32,9 @@ vi.mock("react-pdf", () => ({
     children?: ReactNode;
   }) => {
     currentDocumentFile = file;
+    useEffect(() => {
+      documentMounts();
+    }, []);
     useEffect(() => {
       if (file) onLoadSuccess?.({ numPages: 3 });
     }, [file, onLoadSuccess]);
@@ -76,6 +80,7 @@ describe("PdfPreviewImpl document swap", () => {
   beforeEach(() => {
     currentDocumentFile = null;
     pageMounts.mockClear();
+    documentMounts.mockClear();
 
     vi.stubGlobal(
       "IntersectionObserver",
@@ -109,6 +114,18 @@ describe("PdfPreviewImpl document swap", () => {
 
     await waitFor(() => expect(screen.getByTestId("page-1")).toBeTruthy());
     expect(currentDocumentFile).not.toBeNull();
+  });
+
+  it("remounts <Document> when the url changes", async () => {
+    const { rerender } = render(<PdfPreviewImpl url="/first.pdf" />);
+    await waitFor(() => expect(screen.getByTestId("page-1")).toBeTruthy());
+    expect(documentMounts).toHaveBeenCalledTimes(1);
+
+    // A superseded document's RESOLVE is not cancelled by react-pdf's cleanup,
+    // so reusing the same <Document> lets a destroyed pdf land in context.
+    // A fresh instance per url makes that dispatch a no-op instead.
+    rerender(<PdfPreviewImpl url="/second.pdf" />);
+    await waitFor(() => expect(documentMounts).toHaveBeenCalledTimes(2));
   });
 
   it("renders no pages while the document is still loading", async () => {

--- a/packages/ui/tests/file-preview/pdf-preview-document-swap.test.tsx
+++ b/packages/ui/tests/file-preview/pdf-preview-document-swap.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { createElement, useEffect, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression test for `<Page>` outliving its document.
+ *
+ * When the `url` prop changes, `PdfPreviewImpl` clears `file`, which makes
+ * react-pdf destroy the current document's worker transport. Any `<Page>` that
+ * mounts in that same commit then calls `getPage()` on the dead transport and
+ * throws `Cannot read properties of null (reading 'sendWithPromise')`.
+ *
+ * The mock below reproduces that contract exactly — a `Page` mounting while
+ * its `Document` has no file throws — so the invariant is pinned without
+ * depending on real pdf.js timing.
+ */
+
+let currentDocumentFile: File | null = null;
+const pageMounts = vi.fn();
+
+vi.mock("react-pdf", () => ({
+  pdfjs: { GlobalWorkerOptions: { workerSrc: "" }, version: "0.0.0-test" },
+  PasswordResponses: { NEED_PASSWORD: 1, INCORRECT_PASSWORD: 2 },
+  Document: ({
+    file,
+    onLoadSuccess,
+    children,
+  }: {
+    file: File | null;
+    onLoadSuccess?: (doc: { numPages: number }) => void;
+    children?: ReactNode;
+  }) => {
+    currentDocumentFile = file;
+    useEffect(() => {
+      if (file) onLoadSuccess?.({ numPages: 3 });
+    }, [file, onLoadSuccess]);
+    return createElement("div", { "data-testid": "document" }, children);
+  },
+  Page: ({
+    pageNumber,
+    onLoadSuccess,
+  }: {
+    pageNumber: number;
+    onLoadSuccess?: (page: unknown) => void;
+  }) => {
+    if (!currentDocumentFile) {
+      throw new Error(
+        `<Page ${pageNumber}> mounted while <Document> had no file — ` +
+          "this is the destroyed-transport crash"
+      );
+    }
+    pageMounts(pageNumber);
+    useEffect(() => {
+      onLoadSuccess?.({
+        pageNumber,
+        getViewport: () => ({ width: 600, height: 800 }),
+      });
+    }, [pageNumber, onLoadSuccess]);
+    return createElement("div", { "data-testid": `page-${pageNumber}` });
+  },
+}));
+
+const { PdfPreviewImpl } = await import(
+  "../../src/file-preview/pdf-preview-impl"
+);
+
+function pdfResponse() {
+  return {
+    ok: true,
+    statusText: "OK",
+    blob: async () => new Blob(["%PDF-1.4"], { type: "application/pdf" }),
+  } as unknown as Response;
+}
+
+describe("PdfPreviewImpl document swap", () => {
+  beforeEach(() => {
+    currentDocumentFile = null;
+    pageMounts.mockClear();
+
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => pdfResponse())
+    );
+    Element.prototype.scrollTo = vi.fn();
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("never renders pages once the document's file is cleared", async () => {
+    const { rerender } = render(<PdfPreviewImpl url="/first.pdf" />);
+
+    await waitFor(() => expect(screen.getByTestId("page-1")).toBeTruthy());
+    expect(pageMounts).toHaveBeenCalled();
+
+    // Swapping the url tears the first document down and loads a second one.
+    // The old page count must not survive into that window.
+    rerender(<PdfPreviewImpl url="/second.pdf" />);
+
+    await waitFor(() => expect(screen.getByTestId("page-1")).toBeTruthy());
+    expect(currentDocumentFile).not.toBeNull();
+  });
+
+  it("renders no pages while the document is still loading", async () => {
+    let resolveFetch: (value: Response) => void = () => {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>((resolve) => (resolveFetch = resolve)))
+    );
+
+    render(<PdfPreviewImpl url="/slow.pdf" />);
+
+    expect(screen.queryByTestId("page-1")).toBeNull();
+    expect(pageMounts).not.toHaveBeenCalled();
+
+    resolveFetch(pdfResponse());
+    await waitFor(() => expect(screen.getByTestId("page-1")).toBeTruthy());
+  });
+});

--- a/packages/ui/tests/file-preview/pdfjs-config.test.ts
+++ b/packages/ui/tests/file-preview/pdfjs-config.test.ts
@@ -1,0 +1,106 @@
+import { createRequire } from "module";
+import { readFileSync } from "fs";
+import { globSync } from "glob";
+import path from "path";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const packageRoot = path.resolve(__dirname, "../..");
+
+describe("pdfjs asset configuration", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("pins pdfjs-dist to the exact build react-pdf uses", () => {
+    // The worker we resolve from `pdfjs-dist` must be the same build as the
+    // pdf.js API that react-pdf imports — pdf.js rejects a worker whose
+    // version differs from the API's, which would break every PDF preview.
+    const ownPkg = JSON.parse(
+      readFileSync(path.join(packageRoot, "package.json"), "utf8")
+    );
+    const pinned = ownPkg.dependencies["pdfjs-dist"];
+    expect(pinned).toMatch(/^\d+\.\d+\.\d+$/); // exact, not a range
+
+    const reactPdfRequire = createRequire(
+      require.resolve("react-pdf/package.json")
+    );
+    const resolved = JSON.parse(
+      readFileSync(reactPdfRequire.resolve("pdfjs-dist/package.json"), "utf8")
+    ).version;
+
+    expect(pinned).toBe(resolved);
+  });
+
+  it("does not default any pdf.js asset to a third-party CDN", async () => {
+    const { getPdfjsWorkerSrc, getPdfDocumentOptions } = await import(
+      "../../src/file-preview/pdfjs-config"
+    );
+
+    // The worker executes with the host page's privileges, so whatever the
+    // bundler resolves it to must stay on the app's own origin. CMaps and WASM
+    // are opt-in, not CDN-backed.
+    const workerSrc = getPdfjsWorkerSrc() ?? "";
+    expect(new URL(workerSrc, window.location.href).origin).toBe(
+      window.location.origin
+    );
+    expect(getPdfDocumentOptions()).toEqual({
+      cMapUrl: undefined,
+      wasmUrl: undefined,
+    });
+  });
+
+  it("applies configured asset locations", async () => {
+    const { configurePdfjs, getPdfjsWorkerSrc, getPdfDocumentOptions } =
+      await import("../../src/file-preview/pdfjs-config");
+
+    configurePdfjs({
+      workerSrc: "/pdfjs/pdf.worker.min.mjs",
+      cMapUrl: "/pdfjs/cmaps/",
+      wasmUrl: "/pdfjs/wasm/",
+    });
+
+    expect(getPdfjsWorkerSrc()).toBe("/pdfjs/pdf.worker.min.mjs");
+    expect(getPdfDocumentOptions()).toEqual({
+      cMapUrl: "/pdfjs/cmaps/",
+      wasmUrl: "/pdfjs/wasm/",
+    });
+  });
+
+  it("merges partial configuration and keeps the default worker", async () => {
+    const { configurePdfjs, getPdfjsWorkerSrc } = await import(
+      "../../src/file-preview/pdfjs-config"
+    );
+
+    const defaultWorkerSrc = getPdfjsWorkerSrc();
+    configurePdfjs({ cMapUrl: "/pdfjs/cmaps/" });
+
+    expect(getPdfjsWorkerSrc()).toBe(defaultWorkerSrc);
+  });
+
+  it("keeps a stable <Document options> identity until reconfigured", async () => {
+    const { configurePdfjs, getPdfDocumentOptions } = await import(
+      "../../src/file-preview/pdfjs-config"
+    );
+
+    // react-pdf warns and reloads the document when `options` changes identity.
+    expect(getPdfDocumentOptions()).toBe(getPdfDocumentOptions());
+
+    const before = getPdfDocumentOptions();
+    configurePdfjs({ cMapUrl: "/pdfjs/cmaps/" });
+    expect(getPdfDocumentOptions()).not.toBe(before);
+    expect(getPdfDocumentOptions()).toBe(getPdfDocumentOptions());
+  });
+
+  it("loads no runtime code from a public CDN anywhere in src", () => {
+    const offenders = globSync("src/**/*.{ts,tsx}", { cwd: packageRoot })
+      .filter((file) =>
+        /\bunpkg\.com|\bcdn\.jsdelivr\.net|\bcdnjs\.cloudflare\.com/.test(
+          readFileSync(path.join(packageRoot, file), "utf8")
+        )
+      )
+      .sort();
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -44,10 +44,17 @@ export default defineConfig({
   target: "es2017",
   splitting: true,
   treeshake: true,
-  esbuildOptions(options) {
+  esbuildOptions(options, context) {
     options.alias = {
       "@": process.cwd(),
       "@shared": path.resolve(process.cwd(), "../../shared"),
     };
+    // The es2017 target makes esbuild lower `import.meta` to `{}`, which would
+    // break the bundler-resolved pdf.js worker URL in src/file-preview.
+    // Preserve it for the ESM output only — emitting it into CJS would be a
+    // syntax error.
+    if (context.format === "esm") {
+      options.supported = { ...options.supported, "import-meta": true };
+    }
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,9 @@ importers:
       motion:
         specifier: ^12.12.1
         version: 12.34.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      pdfjs-dist:
+        specifier: 5.4.296
+        version: 5.4.296
       pptx-svg:
         specifier: ^0.5.4
         version: 0.5.4
@@ -2790,6 +2793,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react-swc@4.1.0':
     resolution: {integrity: sha512-Ff690TUck0Anlh7wdIcnsVMhofeEVgm44Y4OYdeeEEPSKyZHzDI9gfVBvySEhDfXtBp8tLCbfsVKPWEMEjq8/g==}
@@ -2871,6 +2875,7 @@ packages:
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xyflow/react@12.8.6':
     resolution: {integrity: sha512-SksAm2m4ySupjChphMmzvm55djtgMDPr+eovPDdTnyGvShf73cvydfoBfWDFllooIQ4IaiUL5yfxHRwU0c37EA==}
@@ -5483,6 +5488,7 @@ packages:
   recharts@2.15.4:
     resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -5996,6 +6002,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0


### PR DESCRIPTION
## Problem

`packages/ui/src/file-preview/pdf-preview-impl.tsx` pointed pdf.js at a public CDN:

```ts
pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;

const pdfOptions = {
  cMapUrl: `https://unpkg.com/pdfjs-dist@${pdfjs.version}/cmaps/`,
  wasmUrl: `https://unpkg.com/pdfjs-dist@${pdfjs.version}/wasm/`,
};
```

The worker is a script that executes with the host page's privileges. A hijacked or compromised unpkg response would have full access to the application origin, on every page that previews a document. It also forces consuming apps to allow `https://unpkg.com` in their CSP `script-src` and `worker-src`.

## 1. Self-host the pdf.js runtime assets

- **Worker resolved from the installed package.** New `src/file-preview/pdfjs-config.ts` resolves the worker via `new URL("pdfjs-dist/build/pdf.worker.min.mjs", import.meta.url)`, so the consuming bundler emits it as a same-origin asset. Nothing in `src/` reaches a CDN anymore.
- **`configurePdfjs()` exported** from `@llamaindex/ui/file-preview` for apps that need to point at self-hosted assets explicitly (`workerSrc`, `cMapUrl`, `wasmUrl`).
- **`pdfjs-dist` added as an exact-pinned dependency** (`5.4.296`). pdf.js refuses a worker whose version differs from the API version react-pdf imports, so the pin must track react-pdf's; a test asserts the two stay in lockstep.
- **`tsup.config.ts`:** the `es2017` target made esbuild lower `import.meta` to `{}`, which would have silently degraded every install to pdf.js's main-thread fallback. `import-meta` is now preserved for the ESM output only — emitting it into CJS would be a syntax error.
- **README:** new "PDF viewer assets" section covering the CSP posture and how to enable the optional asset sets.

### Behaviour change

`cMapUrl` and `wasmUrl` are no longer set by default. They are directories, which bundlers cannot resolve automatically, so they are now opt-in: copy `pdfjs-dist/cmaps` and `pdfjs-dist/wasm` into your static assets and register them via `configurePdfjs()`. Without them, PDFs using CID-keyed fonts (typically CJK) render those glyphs blank and JPEG 2000 images fail to decode. Everything else is unaffected.

If the worker cannot be loaded at all — e.g. the CJS build, where `import.meta` is unavailable — pdf.js falls back to rendering on the main thread. Slower, but still same-origin.

## 2. Fallout: a latent teardown race in the viewer

Self-hosting the worker made pdf.js use a **real** Worker in CI, where the unpkg script had been falling back to the in-process fake worker. That turned a latent race into six unhandled errors per run:

```
TypeError: Cannot read properties of null (reading 'sendWithPromise')
  at WorkerTransport.getPage
```

It only reproduces under `--coverage`, whose v8 instrumentation slows execution enough to widen the window, and only when documents actually load. Instrumenting react-pdf gave the sequence — all of it inside the `Upload And Preview` story, which swaps the url mid-play:

```
loadDocument RUN x2   <- document B starts while A is still in flight
destroy EXECUTED      <- A torn down
PageMount x6          <- all six with a null messageHandler
```

react-pdf's loader schedules `loadingTask.destroy()` on cleanup but never cancels that task's pending `RESOLVE` dispatch, so a **superseded document still lands in context and is then destroyed**. Any `<Page>` mounting against it throws. No gating on our own state can prevent this — the stale pdf arrives from inside react-pdf after we have already moved on.

Fix: key `<Document>` by url, so each source gets a fresh instance and the stale resolve dispatches into an unmounted reducer, where it is a no-op. Verified against the reproduction: **216 page mounts, all with a live transport, zero errors** (was 152 live / 6 dead).

The same commit range also clears `numPages` alongside `file` and adds `file` to the page-list render guard — an independent defect where pages could render against a cleared document, pinned by its own test.

## Tests

`tests/file-preview/pdfjs-config.test.ts` (6 tests):

- the `pdfjs-dist` pin is exact and equals the version react-pdf resolves;
- the default worker URL stays on the page's own origin;
- `configurePdfjs()` applies and merges partial configuration;
- `<Document options>` keeps a stable identity until reconfigured (react-pdf reloads the document otherwise);
- no file in `src/` references unpkg, jsDelivr or cdnjs — a regression guard on the actual security property.

`tests/file-preview/pdf-preview-document-swap.test.tsx` (3 tests) mocks react-pdf with the same contract the real library has — a `Page` mounting without a `Document` file throws — and pins both the render guard and the per-url remount deterministically, rather than depending on pdf.js timing. Confirmed the guard test fails without its fix.

Verified locally with the exact CI command (`pnpm coverage`, both projects), plus `pnpm typecheck`, `pnpm lint` (0 errors; the 6 warnings are pre-existing on main), `pnpm format-check` and `pnpm build`. Also checked the built output directly: `dist/*.mjs` carries a live `import.meta.url`, and no `.cjs`/`.js` file contains raw `import.meta`.

## Notes for reviewers, out of scope here

- `PdfPreviewImpl` renders pages with `renderAnnotationLayer={true}` hardcoded and no `externalLinkTarget`/`externalLinkRel`, so link annotations in an uploaded PDF are live in the app origin. Separate question from this PR; left unchanged. Happy to follow up if you want it gated behind a prop.
- The url-change effect lists `pageRange` in its deps, and its cleanup clears `file` unconditionally while the effect body early-returns when the url is unchanged. A caller passing an inline `pageRange={[3, 7]}` gets a new array identity each render, which would blank the viewer. Pre-existing and untouched here.
- The PDF stories fetch from `https://mozilla.github.io/...`, so where that host is unreachable they pass without ever rendering a document — which is why this race was invisible locally until I repointed them at the bundled fixture. Worth considering a local fixture for those stories.