### PR TITLE
Ignore local .pnpm-store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.pnpm-store
 
 # Editor directories and files
 .vscode/*
@@ -34,7 +35,6 @@ coverage
 *.tsbuildinfo
 playwright-report
 test-results
-
 
 # env
 .env


### PR DESCRIPTION
## Summary
- Ignore `.pnpm-store` so Cursor/sandbox installs that put the pnpm store in-repo do not show up as untracked files (same gap we hit on platform).

No changeset needed.

## Test plan
- [x] `git status` after a Cursor/sandbox `pnpm install` does not list `.pnpm-store/`
- [x] A normal terminal `pnpm install` still uses `~/Library/pnpm/store`


Made with [Cursor](https://cursor.com)