### PR TITLE
Fix extract table citation paths on paginated pages

### DIFF
--- a/.changeset/extract-table-pagination-index.md
+++ b/.changeset/extract-table-pagination-index.md
@@ -1,0 +1,10 @@
+---
+"@llamaindex/ui": patch
+---
+
+Fix extract table citation paths on paginated pages
+
+Paginated `TableRenderer` and `ListRenderer` rows used the page-local map
+index for hover/click citation paths, so later pages looked up the first
+page of `field_metadata`. Pagination now keeps each row's original index
+in the full array.

--- a/packages/ui/src/extracted-data/data-pagination.tsx
+++ b/packages/ui/src/extracted-data/data-pagination.tsx
@@ -8,6 +8,22 @@ import {
 import { cn } from "@/lib";
 import { Dispatch, SetStateAction } from "react";
 
+export function paginate<T>({
+  items,
+  currentPage,
+  perPage,
+}: {
+  items: T[];
+  currentPage: number;
+  perPage: number;
+}): Array<{ item: T; index: number }> {
+  const start = (currentPage - 1) * perPage;
+  return items.slice(start, start + perPage).map((item, offset) => ({
+    item,
+    index: start + offset,
+  }));
+}
+
 export function DataPagination({
   currentPage,
   setCurrentPage,

--- a/packages/ui/src/extracted-data/list-renderer/list-renderer.tsx
+++ b/packages/ui/src/extracted-data/list-renderer/list-renderer.tsx
@@ -18,7 +18,7 @@ import type { PrimitiveValue, RendererMetadata } from "../types";
 import type { ExtractedFieldMetadata } from "@/src/lib/agent-data";
 import { findFieldSchemaMetadata } from "../metadata-path-utils";
 import { findExtractedFieldMetadata } from "../metadata-lookup";
-import { DataPagination } from "../data-pagination";
+import { DataPagination, paginate } from "../data-pagination";
 import { useState } from "react";
 
 interface ListRendererProps<S extends PrimitiveValue> {
@@ -139,10 +139,11 @@ export function ListRenderer<S extends PrimitiveValue>({
     );
   }
 
-  const visibleData = data.slice(
-    (currentPage - 1) * listItemsPerPage,
-    currentPage * listItemsPerPage
-  );
+  const visibleItems = paginate({
+    items: data,
+    currentPage,
+    perPage: listItemsPerPage,
+  });
 
   return (
     <div className="border rounded-md bg-card overflow-auto">
@@ -154,7 +155,7 @@ export function ListRenderer<S extends PrimitiveValue>({
       />
       <Table>
         <TableBody>
-          {visibleData.map((item, index) => {
+          {visibleItems.map(({ item, index }) => {
             // Check if this specific array item has been changed
             const isChanged = isArrayItemChanged(changedPaths, keyPath, index);
 

--- a/packages/ui/src/extracted-data/table-renderer/table-renderer.tsx
+++ b/packages/ui/src/extracted-data/table-renderer/table-renderer.tsx
@@ -12,7 +12,7 @@ import {
   TableCell,
 } from "@/base/table";
 import { Badge } from "@/base/badge";
-import { DataPagination } from "../data-pagination";
+import { DataPagination, paginate } from "../data-pagination";
 import { EditableField } from "../editable-field";
 import { getFieldDisplayInfo } from "../field-display-utils";
 import { getConfidenceBorderClass } from "../confidence-utils";
@@ -359,10 +359,11 @@ export function TableRenderer<Row extends JsonObject>({
     return rows;
   };
 
-  const visibleData = data.slice(
-    (currentPage - 1) * tableRowsPerPage,
-    currentPage * tableRowsPerPage
-  );
+  const visibleRows = paginate({
+    items: data,
+    currentPage,
+    perPage: tableRowsPerPage,
+  });
 
   return (
     <>
@@ -375,7 +376,7 @@ export function TableRenderer<Row extends JsonObject>({
       <Table>
         <TableHeader>{generateHeaderRows()}</TableHeader>
         <TableBody>
-          {visibleData.map((item, rowIndex) => (
+          {visibleRows.map(({ item, index: rowIndex }) => (
             <TableRow key={rowIndex} state="hover">
               {columns.map((column, colIndex) => {
                 const value = getValue(item, column) as

--- a/packages/ui/tests/extracted-data/data-pagination.test.ts
+++ b/packages/ui/tests/extracted-data/data-pagination.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { paginate } from "@/src/extracted-data/data-pagination";
+
+describe("paginate", () => {
+  const items = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"];
+
+  it("keeps original indices on page 1", () => {
+    expect(paginate({ items, currentPage: 1, perPage: 10 })).toEqual([
+      { item: "a", index: 0 },
+      { item: "b", index: 1 },
+      { item: "c", index: 2 },
+      { item: "d", index: 3 },
+      { item: "e", index: 4 },
+      { item: "f", index: 5 },
+      { item: "g", index: 6 },
+      { item: "h", index: 7 },
+      { item: "i", index: 8 },
+      { item: "j", index: 9 },
+    ]);
+  });
+
+  it("keeps original indices on page 2+", () => {
+    expect(paginate({ items, currentPage: 2, perPage: 10 })).toEqual([
+      { item: "k", index: 10 },
+      { item: "l", index: 11 },
+    ]);
+  });
+});

--- a/packages/ui/tests/extracted-data/list-renderer/list-renderer.pagination.test.tsx
+++ b/packages/ui/tests/extracted-data/list-renderer/list-renderer.pagination.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ListRenderer } from "@/src/extracted-data/list-renderer";
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+describe("ListRenderer pagination citation paths", () => {
+  it("uses absolute item indexes for hover and click paths on page 2+", async () => {
+    window.ResizeObserver = ResizeObserverMock;
+    const user = userEvent.setup();
+    const onHoverField = vi.fn();
+    const onClickField = vi.fn();
+    const data = Array.from({ length: 16 }, (_, i) => `item-${i}`);
+
+    render(
+      <ListRenderer
+        data={data}
+        onUpdate={vi.fn()}
+        keyPath={["tags"]}
+        editable={false}
+        onHoverField={onHoverField}
+        onClickField={onClickField}
+      />
+    );
+
+    await user.click(screen.getByLabelText("Go to next page"));
+    expect(screen.getByText(/Page 2 \/ 2/)).toBeInTheDocument();
+    expect(screen.getByText("item-15")).toBeInTheDocument();
+    expect(screen.queryByText("item-5")).not.toBeInTheDocument();
+
+    const trigger = screen
+      .getByText("item-15")
+      .closest('[data-testid="editable-field-trigger"]');
+    expect(trigger).toBeTruthy();
+
+    fireEvent.mouseEnter(trigger!);
+    expect(onHoverField).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: ["tags", "15"],
+      })
+    );
+    expect(onHoverField).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: ["tags", "5"],
+      })
+    );
+
+    fireEvent.click(trigger!);
+    expect(onClickField).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: ["tags", "15"],
+      })
+    );
+    expect(onClickField).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: ["tags", "5"],
+      })
+    );
+  });
+});

--- a/packages/ui/tests/extracted-data/table-renderer/table-renderer.pagination.test.tsx
+++ b/packages/ui/tests/extracted-data/table-renderer/table-renderer.pagination.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { TableRenderer } from "@/src/extracted-data/table-renderer";
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+describe("TableRenderer pagination citation paths", () => {
+  it("uses absolute row indexes for hover and click paths on page 2+", async () => {
+    window.ResizeObserver = ResizeObserverMock;
+    const user = userEvent.setup();
+    const onHoverField = vi.fn();
+    const onClickField = vi.fn();
+    const data = Array.from({ length: 16 }, (_, i) => ({
+      name: `creditor-${i}`,
+    }));
+
+    render(
+      <TableRenderer
+        data={data}
+        keyPath={["creditors"]}
+        editable={false}
+        onHoverField={onHoverField}
+        onClickField={onClickField}
+      />
+    );
+
+    await user.click(screen.getByLabelText("Go to next page"));
+    expect(screen.getByText(/Page 2 \/ 2/)).toBeInTheDocument();
+    expect(screen.getByText("creditor-15")).toBeInTheDocument();
+    expect(screen.queryByText("creditor-5")).not.toBeInTheDocument();
+
+    const trigger = screen
+      .getByText("creditor-15")
+      .closest('[data-testid="editable-field-trigger"]');
+    expect(trigger).toBeTruthy();
+
+    fireEvent.mouseEnter(trigger!);
+    expect(onHoverField).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: ["creditors", "15", "name"],
+      })
+    );
+    expect(onHoverField).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: ["creditors", "5", "name"],
+      })
+    );
+
+    fireEvent.click(trigger!);
+    expect(onClickField).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: ["creditors", "15", "name"],
+      })
+    );
+    expect(onClickField).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: ["creditors", "5", "name"],
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Paginated `TableRenderer` / `ListRenderer` rows used the page-local `map` index for citation paths, so hover/click on page 2+ looked up `field_metadata` for rows `0–9` instead of `10–19`, etc.
- Pagination now returns `{ item, index }` with the original index in the full array, so hover, click, edit, and delete all use that path (e.g. `creditors.15.name` on page 2).
- Adds unit coverage for `paginate` and component tests that go to page 2 and assert `onHoverField` / `onClickField` use `"15"`, not `"5"`.

## Test plan
- [x] Open a large Extract results table (≥11 rows)
- [x] Go to page 2 and hover a later row (visible slot 5 = data index 15)
- [x] Confirm the PDF highlight uses that row’s bbox, not the first-page row
- [x] Click the same cell and confirm the citation path matches the JSON Result tab
- [x] Repeat for a paginated list field
- [x] `pnpm --filter @llamaindex/ui exec vitest run --project unit tests/extracted-data/data-pagination.test.ts tests/extracted-data/table-renderer/table-renderer.pagination.test.tsx tests/extracted-data/list-renderer/list-renderer.pagination.test.tsx`


Made with [Cursor](https://cursor.com)